### PR TITLE
Updating post-incubation links

### DIFF
--- a/netbeans.apache.org/build.gradle
+++ b/netbeans.apache.org/build.gradle
@@ -62,7 +62,7 @@ task preprocessContentAssets(type: Copy,
     filteringCharset 'UTF-8'
     includeEmptyDirs false
     
-    include "**/*.js", "**/.css", "**/css/*.css", 
+    include "**/*.js", "**/*.css", "**/css/*.css", 
         "dtds/**",
         "**/*.png", "**/*.gif",
         "**/*.jpeg", "**/*.jpg",

--- a/netbeans.apache.org/src/content/community/committer.asciidoc
+++ b/netbeans.apache.org/src/content/community/committer.asciidoc
@@ -26,35 +26,35 @@
 :toc-title:
 
 
-The Committer, Member and (P)PMC Member terms, in particular, have very specific meanings in the Apache Software Foundation
+The Committer, Member and PMC Member terms, in particular, have very specific meanings in the Apache Software Foundation
 (see also link:https://www.apache.org/foundation/how-it-works.html[how the ASF works]), and need to be used appropriately to avoid confusion:
 
-. Everyone who is listed link:https://wiki.apache.org/incubator/NetBeansProposal[at the Apache NetBeans Proposal] can become an Apache NetBeans committer and PPMC (Podling Project Management Committee) member by submitting the required paperwork. 
+. Everyone who is listed link:https://wiki.apache.org/incubator/NetBeansProposal[at the Apache NetBeans Proposal] can become an Apache NetBeans committer and PMC member by submitting the required paperwork. 
 For those in that list, the final step in becoming a committer is to send your iCLA (link:https://www.apache.org/licenses/icla.pdf[individual contributor license agreement (pdf)]) to Apache. 
 Under "preferred Apache id(s)", please put an ID of your choice, which does not already exist (check link:http://people.apache.org/committer-index.html[here].
 Please print out the iCLA, complete it and sign it, scan it, and then e-mail the PDF file to link:mailto:secretary@apache.org[secretary@apache.org]. 
 Once you have sent in your iCLA, you will receive a notification and your Apache ID. You will then be ready to commit code to Apache NetBeans, once the code has been transferred from Oracle. 
-NetBeans PPMC members should also join link:mailto:private@netbeans.incubator.apache.org[private@netbeans.incubator.apache.org] (by sending a 
-mail to link:mailto:private-subscribe@netbeans.incubator.apache.org[private-subscribe@netbeans.incubator.apache.org] which is the PPMC's private list. 
+NetBeans PMC members should also join link:mailto:private@netbeans.apache.org[private@netbeans.apache.org] (by sending a 
+mail to link:mailto:private-subscribe@netbeans.apache.org[private-subscribe@netbeans.apache.org] which is the PMC's private list. 
 Only things that really need to be private are discussed there, such as candidates for committership but not much more than that. 
 As usual at the ASF, everything happens in the open unless really really required.
 
-. Other community members can become Apache NetBeans committers (and maybe also PPMC members) once the NetBeans PPMC elects them to those roles, based on people's merit as usual in Apache projects - you don't ask for committership but add value to the project and expect the PMC to recognize that and vote you in, in due time. See the Process section below.
+. Other community members can become Apache NetBeans committers (and maybe also PMC members) once the NetBeans PMC elects them to those roles, based on people's merit as usual in Apache projects - you don't ask for committership but add value to the project and expect the PMC to recognize that and vote you in, in due time. See the Process section below.
 
-. Being a NetBeans committer or PPMC member does *not* make you an Apache Software Foundation (ASF) Member - that's a different status that's granted by existing Members 
+. Being a NetBeans committer or PMC member does *not* make you an Apache Software Foundation (ASF) Member - that's a different status that's granted by existing Members 
 to people who show an interest in and add value to the Foundation as a whole, see link:https://www.apache.org/foundation/how-it-works.html#roles[https://www.apache.org/foundation/how-it-works.html#roles].
 
-== For (P)PMC members: Committer / (P)PMC member election process
+== For PMC members: Committer / PMC member election process
 
 The process is similar to other Apache projects, such as link:https://github.com/apache/cordova-new-committer-and-pmc[Apache Cordova]:
 
-. A (P)PMC member starts a *[DISCUSS]* thread on the private@ list explaining why you want to elect someone, based on their merit, activity and involvement of a contributor.
-. If there's no opposition, the (P)PMC member starts a *[VOTE]* thread on the private@ mailing list to turn the contributor into a committer and/or a (P)PMC member. Make sure to specify which role you want to elect the people for. (Example text etc to come.)
+. A PMC member starts a *[DISCUSS]* thread on the private@ list explaining why you want to elect someone, based on their merit, activity and involvement of a contributor.
+. If there's no opposition, the PMC member starts a *[VOTE]* thread on the private@ mailing list to turn the contributor into a committer and/or a PMC member. Make sure to specify which role you want to elect the people for. (Example text etc to come.)
 . After at least 72 hours, tally the vote with a *[VOTE][RESULT]* message. (Example text etc to come.)
-. Send the *[NOTICE]* to Incubator PMC and wait 72 hours. (Example text etc to come.)
+. Send the *[NOTICE]* to PMC and wait 72 hours. (Example text etc to come.)
 . Send invitation to the committer, to invite them to be a committer. Example invitations: link:https://cwiki.apache.org/confluence/display/FLEX/New+committer+or+PMC+member+invitation[from the FLEX project],
 or link:http://apache-wicket.1842946.n4.nabble.com/Re-Invitation-to-become-Wicket-committer-Andrea-del-Bene-td4660253.html[Apache Wicket].
 . An account needs to be created for the new committer, if they accept the invitation that was sent.
-. Once created, the new user can then be added as a committer at link:https://whimsy.apache.org/roster/ppmc/netbeans[whimsy.apache.org]
-. Then add the PPMC member at link:https://whimsy.apache.org/roster/ppmc/netbeans[whimsy.apache.org] and optionally announce on the dev list (Example text to come).
+. Once created, the new user can then be added as a committer at link:https://whimsy.apache.org/roster/committee/netbeans#committers[whimsy.apache.org]
+. Then add the PMC member at link:https://whimsy.apache.org/roster/committee/netbeans[whimsy.apache.org] and optionally announce on the dev list (Example text to come).
 

--- a/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
+++ b/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
@@ -44,10 +44,10 @@ This list is also useful as well for those using the NetBeans APIs to develop mo
 
 Using prefix tags in the subject line, such as [ java ] or [ javascript ] is encouraged, to clearly distinguish the topic you're addressing in your e-mail.
 
-- Mailing list address: link:mailto:users@netbeans.incubator.apache.org[users@netbeans.incubator.apache.org]
-- To subscribe please send an email to: link:mailto:users-subscribe@netbeans.incubator.apache.org[users-subscribe@netbeans.incubator.apache.org]
-- To unsubscribe please send an email to: link:mailto:users-unsubscribe@netbeans.incubator.apache.org[users-unsubscribe@netbeans.incubator.apache.org]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-users/[See the Apache mailing list archive]
+- Mailing list address: link:mailto:users@netbeans.apache.org[users@netbeans.apache.org]
+- To subscribe please send an email to: link:mailto:users-subscribe@netbeans.apache.org[users-subscribe@netbeans.apache.org]
+- To unsubscribe please send an email to: link:mailto:users-unsubscribe@netbeans.apache.org[users-unsubscribe@netbeans.apache.org]
+- link:http://mail-archives.apache.org/mod_mbox/netbeans-users/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?users@netbeans.apache.org">Pony mail archive</a> +++
 
 [[dev]]
@@ -57,10 +57,10 @@ Specifically for those committed to working on the development of Apache
 NetBeans itself, as well as those committed to promoting and documenting it,
 via events and tutorials, etc.
 
-- Mailing list address: link:mailto:dev@netbeans.incubator.apache.org[dev@netbeans.incubator.apache.org]
-- To subscribe please send an email to: link:mailto:dev-subscribe@netbeans.incubator.apache.org[dev-subscribe@netbeans.incubator.apache.org]
-- To unsubscribe please send an email to: link:mailto:dev-unsubscribe@netbeans.incubator.apache.org[dev-unsubscribe@netbeans.incubator.apache.org]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-dev/[See the Apache mailing list archive]
+- Mailing list address: link:mailto:dev@netbeans.apache.org[dev@netbeans.apache.org]
+- To subscribe please send an email to: link:mailto:dev-subscribe@netbeans.apache.org[dev-subscribe@netbeans.apache.org]
+- To unsubscribe please send an email to: link:mailto:dev-unsubscribe@netbeans.apache.org[dev-unsubscribe@netbeans.apache.org]
+- link:http://mail-archives.apache.org/mod_mbox/netbeans-dev/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?dev@netbeans.apache.org">Pony mail archive</a> +++
 
 [[netcat]]
@@ -68,10 +68,10 @@ via events and tutorials, etc.
 
 Specifically for those involved in the NetBeans Community Acceptance Testing (NetCAT) program.
 
-- Mailing list address: link:mailto:netcat@netbeans.incubator.apache.org[netcat@netbeans.incubator.apache.org]
-- To subscribe please send an email to: link:mailto:netcat-subscribe@netbeans.incubator.apache.org[netcat-subscribe@netbeans.incubator.apache.org]
-- To unsubscribe please send an email to: link:mailto:netcat-unsubscribe@netbeans.incubator.apache.org[netcat-unsubscribe@netbeans.incubator.apache.org]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-netcat/[See the Apache mailing list archive]
+- Mailing list address: link:mailto:netcat@netbeans.apache.org[netcat@netbeans.apache.org]
+- To subscribe please send an email to: link:mailto:netcat-subscribe@netbeans.apache.org[netcat-subscribe@netbeans.apache.org]
+- To unsubscribe please send an email to: link:mailto:netcat-unsubscribe@netbeans.apache.org[netcat-unsubscribe@netbeans.apache.org]
+- link:http://mail-archives.apache.org/mod_mbox/netbeans-netcat/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?netcat@netbeans.apache.org">Pony mail archive</a> +++
 
 [[announce]]
@@ -82,20 +82,20 @@ for those who do not want to get much traffic though want to keep up with the
 high level developments of Apache NetBeans. No one other than administrators
 are able to write to this mailing list.
 
-- Mailing list address: link:mailto:announce@netbeans.incubator.apache.org[announce@netbeans.incubator.apache.org]
-- To subscribe please send an email to: link:mailto:announce-subscribe@netbeans.incubator.apache.org[announce-subscribe@netbeans.incubator.apache.org]
-- To unsubscribe please send an email to: link:mailto:announce-unsubscribe@netbeans.incubator.apache.org[announce-unsubscribe@netbeans.incubator.apache.org]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-announce/[See the Apache mailing list archive]
+- Mailing list address: link:mailto:announce@netbeans.apache.org[announce@netbeans.apache.org]
+- To subscribe please send an email to: link:mailto:announce-subscribe@netbeans.apache.org[announce-subscribe@netbeans.apache.org]
+- To unsubscribe please send an email to: link:mailto:announce-unsubscribe@netbeans.apache.org[announce-unsubscribe@netbeans.apache.org]
+- link:http://mail-archives.apache.org/mod_mbox/netbeans-announce/[See the Apache mailing list archive]
 
 [[commits]]
 === Commits list
 
 Receive GitHub commit messages whenever a commit is done.
 
-- Mailing list address: link:mailto:commits@netbeans.incubator.apache.org[commits@netbeans.incubator.apache.org]
-- To subscribe please send an email to: link:mailto:commits-subscribe@netbeans.incubator.apache.org[commits-subscribe@netbeans.incubator.apache.org]
-- To unsubscribe please send an email to: link:mailto:commits-unsubscribe@netbeans.incubator.apache.org[commits-unsubscribe@netbeans.incubator.apache.org]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-commits/[See the Apache mailing list archive]
+- Mailing list address: link:mailto:commits@netbeans.apache.org[commits@netbeans.apache.org]
+- To subscribe please send an email to: link:mailto:commits-subscribe@netbeans.apache.org[commits-subscribe@netbeans.apache.org]
+- To unsubscribe please send an email to: link:mailto:commits-unsubscribe@netbeans.apache.org[commits-unsubscribe@netbeans.apache.org]
+- link:http://mail-archives.apache.org/mod_mbox/netbeans-commits/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?commits@netbeans.apache.org">Pony mail archive</a> +++
 
 [[notifications]]
@@ -103,10 +103,10 @@ Receive GitHub commit messages whenever a commit is done.
 
 Receive GitHub notifications whenever someone adds a comment to an issue and whenever a new pull request is opened or closed.
 
-- Mailing list address: link:mailto:notifications@netbeans.incubator.apache.org[notifications@netbeans.incubator.apache.org]
-- To subscribe please send an email to: link:mailto:notifications-subscribe@netbeans.incubator.apache.org[notifications-subscribe@netbeans.incubator.apache.org]
-- To unsubscribe please send an email to: link:mailto:notifications-unsubscribe@netbeans.incubator.apache.org[notifications-unsubscribe@netbeans.incubator.apache.org]
-- link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-notifications/[See the Apache mailing list archive]
+- Mailing list address: link:mailto:notifications@netbeans.apache.org[notifications@netbeans.apache.org]
+- To subscribe please send an email to: link:mailto:notifications-subscribe@netbeans.apache.org[notifications-subscribe@netbeans.apache.org]
+- To unsubscribe please send an email to: link:mailto:notifications-unsubscribe@netbeans.apache.org[notifications-unsubscribe@netbeans.apache.org]
+- link:http://mail-archives.apache.org/mod_mbox/netbeans-notifications/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?notifications@netbeans.apache.org">Pony mail archive</a> +++
 
 == Other channels
@@ -115,5 +115,5 @@ Receive GitHub notifications whenever someone adds a comment to an issue and whe
 - We also have a link:https://www.youtube.com/user/netbeansvideos[YouTube] channel.
 - Meet other users in the unofficial link:https://tinyurl.com/netbeans-slack-signup[NetBeans Slack channel]
 - There is also a NetBeans IRC channel (#netbeans) on link:https://freenode.net/[freenode].
-- Finally we use link:https://github.com/apache/incubator-netbeans[GitHub] as a source repository and link:https://issues.apache.org/jira/projects/NETBEANS/summary[JIRA] for issue reporting.
+- Finally we use link:https://github.com/apache/netbeans[GitHub] as a source repository and link:https://issues.apache.org/jira/projects/NETBEANS/summary[JIRA] for issue reporting.
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -67,14 +67,14 @@ link:nb90/[Features, role="button"] link:nb90/nb90.html[Download, role="button s
 
 You can of course build Apache NetBeans from source. To do so:
 
-. Clone the https://github.com/apache/incubator-netbeans GitHub repository.
+. Clone the https://github.com/apache/netbeans GitHub repository.
 . Install Oracle's Java 8 or Open JDK v8.
 . Install Apache Ant 1.10 or greater (https://ant.apache.org/).
 
-Once you're all set just enter the `incubator-netbeans` directory and type:
+Once you're all set just enter the `netbeans` directory and type:
 
 - `ant` to build the Apache NetBeans IDE.
-  ** Once built, the IDE bits are placed in the `./nbbuild/netbeans` directory. You can run the IDE from within the `incubator-netbeans` directory by typing `./nbbuild/netbeans/bin/netbeans` on unixes (for Windows the command is equivalent).
+  ** Once built, the IDE bits are placed in the `./nbbuild/netbeans` directory. You can run the IDE from within the `netbeans` directory by typing `./nbbuild/netbeans/bin/netbeans` on unixes (for Windows the command is equivalent).
 - `ant tryme` to run the Apache NetBeans IDE.
 
 For details, go here: https://cwiki.apache.org/confluence/display/NETBEANS/Development+Environment
@@ -86,9 +86,9 @@ Now that you have built Apache NetBeans from source you may want to link:/partic
 
 This is a list of Apache NetBeans (incubating) repositories:
 
-- https://github.com/apache/incubator-netbeans The main source code repository.
-- https://github.com/apache/incubator-netbeans-website This website's repository.
-- https://github.com/apache/incubator-netbeans-website-cleanup A repository used to clean up existing documentation from http://netbeans.org
+- https://github.com/apache/netbeans The main source code repository.
+- https://github.com/apache/netbeans-website This website's repository.
+- https://github.com/apache/netbeans-website-cleanup A repository used to clean up existing documentation from http://netbeans.org
 - Emilian Bold has converted the previous Mercurial repository (http://hg.netbeans.org) to git, for historical reference, and has kindly uploaded it to GitHub at https://github.com/emilianbold/netbeans-releases. Thanks, Emilian!
 
 

--- a/netbeans.apache.org/src/content/help/index.asciidoc
+++ b/netbeans.apache.org/src/content/help/index.asciidoc
@@ -47,8 +47,8 @@ These other resources are available:
 - Visit the link:https://netbeans.org/kb/index.html[netbeans.org docs & support] section in the old website.
 - Our link:https://www.youtube.com/user/NetBeansVideos[YouTube Video Channel] contains many tutorials and tips.
 - The previous link:/wiki/index.asciidoc[wiki] has been partially migrated and is being updated.
-- The link:https://github.com/apache/incubator-netbeans-website-cleanup[content of the previous netbeans.org website] is being cleaned up in github.
-- The link:https://github.com/apache/incubator-netbeans-website[current Apache NetBeans website] (i.e., this website) is also hosted at github.
+- The link:https://github.com/apache/netbeans-website-cleanup[content of the previous netbeans.org website] is being cleaned up in github.
+- The link:https://github.com/apache/netbeans-website[current Apache NetBeans website] (i.e., this website) is also hosted at github.
 
 [[wiki]]
 == Apache NetBeans Wiki

--- a/netbeans.apache.org/src/content/kb/docs/contributing.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/contributing.asciidoc
@@ -39,7 +39,7 @@ This page describes some tips, tricks and conventions for reviewing tutorials fo
 
 The NetBeans website is written mainly in link:http://asciidoc.org/[AsciiDoc], a way of creating technical components using plain text files. 
 
-We then generate HTML for the web using Groovy Server Page templates (these live in https://github.com/apache/incubator-netbeans-website/tree/master/netbeans.apache.org/src/content/templates ). These templates (and some other stuff like SCSS) are responsible for the layout of the web pages. 
+We then generate HTML for the web using Groovy Server Page templates (these live in https://github.com/apache/netbeans-website/tree/master/netbeans.apache.org/src/content/templates ). These templates (and some other stuff like SCSS) are responsible for the layout of the web pages. 
 
 NOTE: The generated HTML is responsive, this is, it can be correctly visualized in mobile phones.
 
@@ -56,7 +56,7 @@ image::images/contributing-link.png[title="Click the 'See this page in GitHub' l
 
 image::images/contributing-button.png[title="Edit button in GitHub"]
 
-If you don't have edit permissions you always can clone the link:https://github.com/apache/incubator-netbeans-website[website repository in GitHub] and then edit the file in your own clone, and then submit that as a Pull Request against the main Apache Repository.
+If you don't have edit permissions you always can clone the link:https://github.com/apache/netbeans-website[website repository in GitHub] and then edit the file in your own clone, and then submit that as a Pull Request against the main Apache Repository.
 
 You can also watch the following YouTube video for instructions:
 

--- a/netbeans.apache.org/src/content/kb/docs/ide/git.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/git.asciidoc
@@ -91,7 +91,7 @@ To clone a repository from GitHub via the SSH protocol, proceed as follows:
 NOTE: You need to have a GitHub account and be a project member in order to clone via SSH.
 
 1. Choose  ``Team``  >  ``Git``  >  ``Clone``  from the main menu. The Clone Repository wizard displays.
-2. At the Remote Repository page of the Clone Repository wizard, specify the path to the repository required in the Repository URL field, for example,  ``git@github.com:apache/incubator-netbeans.git`` .
+2. At the Remote Repository page of the Clone Repository wizard, specify the path to the repository required in the Repository URL field, for example,  ``git@github.com:apache/netbeans.git`` .
 3. Verify  ``git``  is specified in the Username text field.
 4. Select the Private/public key option.
 5. (*Skip if using SSH-agent or Pageant for automated SSH access to the Git server.*) Complete the following steps to access the Git server using your private SSH key and a passphrase:

--- a/netbeans.apache.org/src/content/participate/netcat.asciidoc
+++ b/netbeans.apache.org/src/content/participate/netcat.asciidoc
@@ -43,7 +43,7 @@ This program is the successor of link:http://wiki.netbeans.org/NetCAT[NetCAT] pr
 
 If you have experience with software development and would like to help
 NetBeans become the best IDE, simply fill out the registration form and also
-subscribe to link:mailto:netcat@netbeans.incubator.apache.org[netcat@netbeans.incubator.apache.org] 
+subscribe to link:mailto:netcat@netbeans.apache.org[netcat@netbeans.apache.org] 
 mailing list after submission of the registration form via Subscribe button. If
 you are interested in our previous discussions, browse through the web archive
 of the NetCAT mailing list. See link:/community/mailing-lists.html[mailing lists] for
@@ -57,7 +57,7 @@ acceptable to only evaluate milestone builds, we would truly appreciate it if
 you used and tested the daily development builds.
 
 The main communication channels are link:https://issues.apache.org/jira/browse/NETBEANS[JIRA] and
-netcat@netbeans.incubator.apache.org mailing list, your input may also be
+netcat@netbeans.apache.org mailing list, your input may also be
 requested via additional surveys or online IRC meetings during NetCAT program.
 At the end of the program, you will be asked to submit a Community Acceptance
 (CA) survey in which you can express your opinion as to whether or not the new

--- a/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
+++ b/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
@@ -65,7 +65,7 @@ link:/participate/build-run-debug-tutorials.html[Watch a series of 5 short video
 === Bootstrapping (do this once)
 
 Since you don't have write permissions to the GitHub apache mirror, you need to
-fork https://github.com/apache/incubator-netbeans in GitHub, this is done using
+fork https://github.com/apache/netbeans in GitHub, this is done using
 the "fork" button on the top right of the GitHub page.
 
 You then need to clone the forked repository in your computer.
@@ -81,10 +81,10 @@ git config --global user.email "john@doe.org"
 
 The `--global` argument can be removed if you want to setup only the current repository.
 
-Also add the Apache NetBeans incubator project as your *upstream* in order to submit PRs:
+Also add the Apache NetBeans project as your *upstream* in order to submit PRs:
 
 ```
-git remote add upstream https://github.com/apache/incubator-netbeans.git
+git remote add upstream https://github.com/apache/netbeans.git
 ```
 
 After all this you're ready to submit pull requests.
@@ -107,7 +107,7 @@ Once your code is ready to review create a *pull request* using the GitHub inter
 
 === Be patient
 
-Once your pull request is submitted to Apache NetBeans it will be visible in this address https://github.com/apache/incubator-netbeans/pulls.
+Once your pull request is submitted to Apache NetBeans it will be visible in this address https://github.com/apache/netbeans/pulls.
 
 The pull request will then be reviewed by the link:/community/who.html[NetBeans Team], once there's time to do so. Please be patient, as this may take some time, depending on other duties and ongoing work.
 

--- a/netbeans.apache.org/src/content/templates/footer.gsp
+++ b/netbeans.apache.org/src/content/templates/footer.gsp
@@ -50,7 +50,6 @@
                     <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
                     <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                     <li><a href="https://www.apache.org/security/">Security</a></li>
-                    <li><a href="https://incubator.apache.org/projects/netbeans.html">Incubation Status</a></li>
                 </ul>
             </div>
             <div class="large-auto cell">

--- a/netbeans.apache.org/src/content/templates/tools.gsp
+++ b/netbeans.apache.org/src/content/templates/tools.gsp
@@ -22,7 +22,7 @@
     <ul class="menu align-center">
         <li><a title="Facebook" href="https://www.facebook.com/NetBeans"><i class="fa fa-md fa-facebook"></i></a></li>
         <li><a title="Twitter" href="https://twitter.com/netbeans"><i class="fa fa-md fa-twitter"></i></a></li>
-        <li><a title="Github" href="https://github.com/apache/incubator-netbeans"><i class="fa fa-md fa-github"></i></a></li>
+        <li><a title="Github" href="https://github.com/apache/netbeans"><i class="fa fa-md fa-github"></i></a></li>
         <li><a title="YouTube" href="https://www.youtube.com/user/netbeansvideos"><i class="fa fa-md fa-youtube"></i></a></li>
         <li><a title="Slack" href="https://tinyurl.com/netbeans-slack-signup/"><i class="fa fa-md fa-slack"></i></a></li>
         <li><a title="JIRA" href="https://issues.apache.org/jira/projects/NETBEANS/summary"><i class="fa fa-mf fa-bug"></i></a></li>
@@ -30,7 +30,7 @@
     <ul class="menu align-center">
         <%
             /* 
-                jbake's "content.file' has this structure: "/home/user/directory/of/the/clone/incubator-netbeans-website/netbeans.apache.org/build/generated-bake/content/plugins/index.asciidoc"
+                jbake's "content.file' has this structure: "/home/user/directory/of/the/clone/netbeans-website/netbeans.apache.org/build/generated-bake/content/plugins/index.asciidoc"
                 we're interested in the part after "generated-bake"
             */
             String file="/";
@@ -42,6 +42,6 @@
                 file = content_file.substring(i + "build/generated-bake".length());
             }
         %>
-        <li><a href="https://github.com/apache/incubator-netbeans-website/blob/master/netbeans.apache.org/src${file}" title="See this page in github"><i class="fa fa-md fa-edit"></i> See this page in GitHub.</a></li>
+        <li><a href="https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src${file}" title="See this page in github"><i class="fa fa-md fa-edit"></i> See this page in GitHub.</a></li>
     </ul>
 </section>

--- a/netbeans.apache.org/src/content/templates/tutorial.gsp
+++ b/netbeans.apache.org/src/content/templates/tutorial.gsp
@@ -30,7 +30,7 @@
             <h1 class="sect0">${content.title}</h1>
             <% if (content.reviewed == null) { 
                 /* 
-                    jbake's 'content.file' has this structure: "/home/user/directory/of/the/clone/incubator-netbeans-website/netbeans.apache.org/build/generated-bake/content/plugins/index.asciidoc"
+                    jbake's 'content.file' has this structure: "/home/user/directory/of/the/clone/netbeans-website/netbeans.apache.org/build/generated-bake/content/plugins/index.asciidoc"
                     we're interested in the part after "generated-bake"
                 */
                 String tutorial_file="/";
@@ -47,7 +47,7 @@
                   <td class="icon"><i class="fa icon-note" title="Note"></i></td>
                   <td class="content">This tutorial needs a review. 
                      You can <a href="https://issues.apache.org/jira/projects/NETBEANS/issues">open a JIRA issue</a>, 
-                     or <a href="https://github.com/apache/incubator-netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
+                     or <a href="https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
                      following these <a href="/kb/docs/contributing.html">contribution guidelines.</a></td>
                   </tr></tbody>
                 </table>


### PR DESCRIPTION
This updates the links for the post-incubation era.
Also adds the *.css at / for a future netbeans.org migration.