### PR TITLE
Remove past events and add dates for 2019

### DIFF
--- a/netbeans.apache.org/src/content/community/events.asciidoc
+++ b/netbeans.apache.org/src/content/community/events.asciidoc
@@ -37,24 +37,22 @@ An "Apache NetBeans Day" is a class of event that happens regularly, with a clea
 
 For publicizing NetBeans events, the Apache News posts at https://blogs.apache.org/foundation/ can mention those events, best is to contact press@apache.org for that. Apache has an Event Listing (https://events.apache.org/), that we'd also like to make use of.
 
-=== Apache NetBeans Day UK 2018
+=== Upcoming NetBeans related events in 2019/2020
 
-Was held at the University of Greenwich campus (London) on April the 27th, 2018. See the link:https://www.eventbrite.co.uk/e/apache-netbeans-day-uk-2018-tickets-43401128945[agenda and details] and the dedicated link:https://twitter.com/NetBeansDayUK[Twitter account].
+16-19th September 2019 Oracle CodeOne conference is Oracle's big developer conference for Java and other languages. You have to pay to attend but there are lots of excellent talks. It takes place at the Moscone Center in San Francisco, USA. link::https://www.oracle.com/code-one/[CodeOne Website] Here are the NetBeans related talks link::https://events.rainfocus.com/widget/oracle/oow19/catalogcodeone19?search=netbeans[NetBeans specific talks]
 
-== NetBeans in Other Events
+27th September 2019 Apache NetBeans Day 2019 UK is a free one day conference in  London, UK. link::https://www.eventbrite.co.uk/e/apache-netbeans-day-2019-uk-tickets-56803479737[free tickets and more details]
 
-This is a list of different events where Apache NetBeans was or will be the subject of one or more sessions or talks:
+10th January 2020 Dawscon is a one day software development conference in Montreal, Canada. It will have several NetBeans enthusiastists speaking and at least one dedicated NetBeans talk. link::https://www.dawsoncollege.qc.ca/dawscon/
 
-=== Apache Conference Montreal 2018
-Ken Fogel, "What Makes NetBeans Special", Sept. the 25th, 2018. link:https://apachecon.dukecon.org/acna/2018/#/schedule[click here for more information].
-
-
-== Other Apache Community Events
-
-This is a link to the next Apache Community major event:
+This is a link to the next Apache Community major events:
 
 [caption="Apache Current Event", link=https://www.apache.org/events/current-event.html]
 image::https://www.apache.org/events/current-event-234x60.png[CurrentEvent,234,60]
+
+== Reviews and reports from previous NetBeans related events
+link::https://www.omnijava.com/2019/01/20/dawscon-2019/[Dawscon 2019 write-up]
+link::https://blog.idrsolutions.com/2018/04/key-takeaways-from-apache-netbeans-day-uk/[My Key Takeaways from Apache NetBeans Day UK]
 
 == Apache Software Foundation Resources For Events And Conferences
 


### PR DESCRIPTION
I have added CodeOne 2019 NetBeans links, DawsCon and NetBeans UK2019. I have also removed old 2018 entries but added some write-ups to previous events