### PR TITLE
FIx typo and update text

### DIFF
--- a/netbeans.apache.org/src/content/community/events.asciidoc
+++ b/netbeans.apache.org/src/content/community/events.asciidoc
@@ -39,20 +39,20 @@ For publicizing NetBeans events, the Apache News posts at https://blogs.apache.o
 
 === Upcoming NetBeans related events in 2019/2020
 
-16-19th September 2019 Oracle CodeOne conference is Oracle's big developer conference for Java and other languages. You have to pay to attend but there are lots of excellent talks. It takes place at the Moscone Center in San Francisco, USA. link::https://www.oracle.com/code-one/[CodeOne Website] Here are the NetBeans related talks link::https://events.rainfocus.com/widget/oracle/oow19/catalogcodeone19?search=netbeans[NetBeans specific talks]
+16-19th September 2019 Oracle CodeOne conference is Oracle's big developer conference for Java and other languages. You have to pay to attend but there are lots of excellent talks. It takes place at the Moscone Center in San Francisco, USA. link:https://www.oracle.com/code-one/[CodeOne Website] Here are the NetBeans related talks link:https://events.rainfocus.com/widget/oracle/oow19/catalogcodeone19?search=netbeans[NetBeans specific talks]
 
-27th September 2019 Apache NetBeans Day 2019 UK is a free one day conference in  London, UK. link::https://www.eventbrite.co.uk/e/apache-netbeans-day-2019-uk-tickets-56803479737[free tickets and more details]
+27th September 2019 Apache NetBeans Day 2019 UK is a free one day conference in  London, UK. link:https://www.eventbrite.co.uk/e/apache-netbeans-day-2019-uk-tickets-56803479737[free tickets and more details]
 
 10th January 2020 Dawscon is a one day software development conference in Montreal, Canada. It will have several NetBeans enthusiastists speaking and at least one dedicated NetBeans talk. link::https://www.dawsoncollege.qc.ca/dawscon/
 
 This is a link to the next Apache Community major events:
 
 [caption="Apache Current Event", link=https://www.apache.org/events/current-event.html]
-image::https://www.apache.org/events/current-event-234x60.png[CurrentEvent,234,60]
+image:https://www.apache.org/events/current-event-234x60.png[CurrentEvent,234,60]
 
-== Reviews and reports from previous NetBeans related events
-link::https://www.omnijava.com/2019/01/20/dawscon-2019/[Dawscon 2019 write-up]
-link::https://blog.idrsolutions.com/2018/04/key-takeaways-from-apache-netbeans-day-uk/[My Key Takeaways from Apache NetBeans Day UK]
+== Past events
+link:https://www.omnijava.com/2019/01/20/dawscon-2019/[Dawscon 2019 write-up]
+link:https://blog.idrsolutions.com/2018/04/key-takeaways-from-apache-netbeans-day-uk/[My Key Takeaways from Apache NetBeans Day UK 2018]
 
 == Apache Software Foundation Resources For Events And Conferences
 


### PR DESCRIPTION
Fixed silly typo with link:: instead of link: and added suggestion to have a past events section