### PR TITLE
Update the category name for ant projects

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro.asciidoc
@@ -70,7 +70,7 @@ To open a new Java project, press:
 |*macOS*(TM) |kbd:[Command+Shift+N]
 |===
 
-or, select *File > New Project...* from the menu bar. Then *Choose Project* by selecting *Categories: Java* and *Projects: Java Class Library*, then click *Next >*.
+or, select *File > New Project...* from the menu bar. Then *Choose Project* by selecting *Categories: Java with Ant* and *Projects: Java Class Library*, then click *Next >*.
 
 For *Name and Location*, set *Project Name: MyLib*. Change *Project Location:* to any directory on your computer. From now on, this tutorial refers to this directory as `_NetBeansProjects_`.
 
@@ -84,7 +84,7 @@ Finally, click *Finish*. The MyLib project will be created and opens in the *Pro
 
 === Creating a Java Application Project
 
-Open a new Java Project, as shown above. Then *Choose Project* by selecting *Categories: Java* and *Projects: Java Application*, then click *Next >*.
+Open a new Java Project, as shown above. Then *Choose Project* by selecting *Categories: Java with Ant* and *Projects: Java Application*, then click *Next >*.
 
 for *Name and Location*, set *Project Name: MyApp*. Make sure the Project Location is set to `_NetBeansProjects_`.
 


### PR DESCRIPTION
"Java" category no longer exists as ant projects are no longer the default option in Netbeans.

This tutorial works with ant projects and the current category name for them is "Java with Ant".