### PR TITLE
Website structural updates for NB 11.1.

### DIFF
--- a/netbeans.apache.org/globals.yml
+++ b/netbeans.apache.org/globals.yml
@@ -33,6 +33,8 @@ template:
         file: tutorial.gsp
     page-noaside:
         file: page-noaside.gsp
+    page-front:
+        file: page-front.gsp
     wiki:
         file: wiki.gsp
         extension: .asciidoc

--- a/netbeans.apache.org/src/content/download/archive/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/archive/index.asciidoc
@@ -1,0 +1,52 @@
+
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Apache NetBeans archive
+:jbake-type: page
+:jbake-tags: archive
+:jbake-status: published
+:keywords: Apache NetBeans archive releases
+:icons: font
+:description: Apache NetBeans archive releases
+:linkattrs:
+
+Older Apache NetBeans releases and pre-Apache NetBeans releases can still be
+downloaded, but are no longer supported.
+
+== Apache NetBeans 10.0
+
+Apache NetBeans 10.0 was released on December 27, 2018.
+
+link:/download/nb100/[Features, role="button"] link:/download/nb100/nb100.html[Download, role="button success"]
+
+== Apache NetBeans 9.0
+
+Apache NetBeans 9.0 was released on July 29, 2018.
+
+link:/download/nb90/[Features, role="button"] link:/download/nb90/nb90.html[Download, role="button success"] 
+
+== Pre-Apache NetBeans versions
+
+- https://netbeans.org/downloads/8.2/
+- https://netbeans.org/downloads/8.1/
+- https://netbeans.org/downloads/8.0/
+- https://netbeans.org/downloads/7.4/
+
+
+

--- a/netbeans.apache.org/src/content/download/dev/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/dev/index.asciidoc
@@ -1,0 +1,65 @@
+
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Apache NetBeans source and daily builds
+:jbake-type: page
+:jbake-tags: 
+:jbake-status: published
+:keywords: Apache NetBeans source and daily builds
+:icons: font
+:description: Apache NetBeans source and daily builds
+
+All Apache NetBeans source code is freely available to build yourself, or you can
+download (unsupported) daily development builds.
+
+== Daily builds
+
+Please visit link:https://builds.apache.org/job/netbeans-linux/[https://builds.apache.org/job/netbeans-linux/] and link:https://builds.apache.org/job/netbeans-windows/[https://builds.apache.org/job/netbeans-windows/] for the daily builds.
+
+== Building from source
+
+You can of course build Apache NetBeans from source. To do so:
+
+. Clone the https://github.com/apache/netbeans GitHub repository.
+. Install Oracle's Java 8 or Open JDK v8.
+. Install Apache Ant 1.10 or greater (https://ant.apache.org/).
+
+Once you're all set just enter the `netbeans` directory and type:
+
+- `ant` to build the Apache NetBeans IDE.
+  ** Once built, the IDE bits are placed in the `./nbbuild/netbeans` directory. You can run the IDE from within the `netbeans` directory by typing `./nbbuild/netbeans/bin/netbeans` on unixes (for Windows the command is equivalent).
+- `ant tryme` to run the Apache NetBeans IDE.
+
+For details, go here: https://cwiki.apache.org/confluence/display/NETBEANS/Development+Environment
+
+Now that you have built Apache NetBeans from source you may want to link:/participate/submit-pr.html[submit a pull request].
+
+=== Repositories
+
+This is a list of Apache NetBeans repositories:
+
+- https://github.com/apache/netbeans The main source code repository.
+- https://github.com/apache/netbeans-website This website's repository.
+- https://github.com/apache/netbeans-website-cleanup A repository used to clean up existing documentation from http://netbeans.org
+- Emilian Bold has converted the previous Mercurial repository (http://hg.netbeans.org) to git, for historical reference, and has kindly uploaded it to GitHub at https://github.com/emilianbold/netbeans-releases. Thanks, Emilian!
+
+
+
+
+

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -39,7 +39,7 @@ features. See link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+
 
 == Apache NetBeans 11 feature update 1 (NB 11.1)
 
-Latest release of the IDE, released on July 20, 2019.
+Latest version of the IDE, released on July 22, 2019.
 
 link:/download/nb111/index.html[Features, role="button"] link:/download/nb111/nb111.html[Download, role="button success"]
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -29,74 +29,36 @@ for important requirements for download pages for Apache projects.
 :jbake-status: published
 :keywords: Apache NetBeans releases
 :description: Apache NetBeans Releases Page
-:toc: left
-:toc-title:
 :linkattrs:
 
-[[releases]]
+Apache NetBeans is released four times a year. Our April release is a
+long-term support (LTS) release that benefits from our famous NetCAT
+community testing process, and will remain available and supported for
+a year.  Our other quarterly releases provide early access to new
+features. See link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[full release schedule].
 
-== Apache NetBeans 11.0
+== Apache NetBeans 11 feature update 1 (NB 11.1)
 
-Apache NetBeans 11.0 is the latest version of the IDE. It was released on April 4, 2019.
+Latest release of the IDE, released on July 20, 2019.
 
-link:nb110/index.html[Features, role="button"] link:nb110/nb110.html[Download, role="button success"]
+link:/download/nb111/index.html[Features, role="button"] link:/download/nb111/nb111.html[Download, role="button success"]
 
+== Apache NetBeans 11 LTS (NB 11.0)
 
-== Apache NetBeans 10.0
+Latest LTS version of the IDE, released on April 4, 2019.
 
-Apache NetBeans 10.0 was released on December 27, 2018.
+link:/download/nb110/index.html[Features, role="button"] link:/download/nb110/nb110.html[Download, role="button success"]
 
-link:nb100/index.html[Features, role="button"] link:nb100/nb100.html[Download, role="button success"]
+== Older releases
 
-[[previous]]
-== Apache NetBeans 9.0
+Older Apache NetBeans releases and pre-Apache NetBeans releases can still be
+downloaded, but are no longer supported.
 
-Apache NetBeans 9.0 was released on the July 29, 2018.
+link:/download/archive/index.html[Find out more, role="button"]
 
-link:nb90/[Features, role="button"] link:nb90/nb90.html[Download, role="button success"] 
+== Daily builds and building from source
 
-== Pre-Apache NetBeans versions
+All Apache NetBeans source code is freely available to build yourself, or you can
+download (unsupported) daily development builds.
 
-- https://netbeans.org/downloads/8.2/
-- https://netbeans.org/downloads/8.1/
-- https://netbeans.org/downloads/8.0/
-- https://netbeans.org/downloads/7.4/
-
-== Release schedule
-
-Please visit the link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[release schedule page] for the full release schedule.
-
-== Daily builds
-
-Please visit link:https://builds.apache.org/job/netbeans-linux/[https://builds.apache.org/job/netbeans-linux/] and link:https://builds.apache.org/job/netbeans-windows/[https://builds.apache.org/job/netbeans-windows/] for the daily builds.
-
-[[source]]
-== Building from source
-
-You can of course build Apache NetBeans from source. To do so:
-
-. Clone the https://github.com/apache/netbeans GitHub repository.
-. Install Oracle's Java 8 or Open JDK v8.
-. Install Apache Ant 1.10 or greater (https://ant.apache.org/).
-
-Once you're all set just enter the `netbeans` directory and type:
-
-- `ant` to build the Apache NetBeans IDE.
-  ** Once built, the IDE bits are placed in the `./nbbuild/netbeans` directory. You can run the IDE from within the `netbeans` directory by typing `./nbbuild/netbeans/bin/netbeans` on unixes (for Windows the command is equivalent).
-- `ant tryme` to run the Apache NetBeans IDE.
-
-For details, go here: https://cwiki.apache.org/confluence/display/NETBEANS/Development+Environment
-
-Now that you have built Apache NetBeans from source you may want to link:/participate/submit-pr.html[submit a pull request].
-
-[[repos]]
-=== Repositories
-
-This is a list of Apache NetBeans repositories:
-
-- https://github.com/apache/netbeans The main source code repository.
-- https://github.com/apache/netbeans-website This website's repository.
-- https://github.com/apache/netbeans-website-cleanup A repository used to clean up existing documentation from http://netbeans.org
-- Emilian Bold has converted the previous Mercurial repository (http://hg.netbeans.org) to git, for historical reference, and has kindly uploaded it to GitHub at https://github.com/emilianbold/netbeans-releases. Thanks, Emilian!
-
-
+link:/download/dev/index.html[Find out more, role="button"]

--- a/netbeans.apache.org/src/content/download/nb111/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb111/index.asciidoc
@@ -18,7 +18,7 @@
      under the License.
 ////
 = Apache NetBeans 11.1 Features
-:jbake-type: page
+:jbake-type: page-noaside
 :jbake-tags: 11.1 features
 :jbake-status: published
 :keywords: Apache NetBeans 11.1 IDE features
@@ -30,10 +30,13 @@
 :syntax: true
 :source-highlighter: pygments
 :experimental:
+:linkattrs:
 
 Apache NetBeans 11.1 is the first Apache NetBeans release outside the Apache Incubator and the link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[first release of the new quarterly release cycle].
 
-TIP: The LTS release of the Apache NetBeans 11 cycle is Apache NetBeans 11.0. The 11.1 release has not been tested as heavily as the LTS release and may therefore be less stable. Use 11.1 to use the latest features and to provide feedback for the next LTS release, scheduled for April 2020. Go here to download  link:https://netbeans.apache.org/download/nb110/nb110.html[Apache NetBeans 11.0], the current LTS release.
+TIP: The LTS release of the Apache NetBeans 11 cycle is Apache NetBeans 11.0. The 11.1 release has not been tested as heavily as the LTS release and may therefore be less stable. Use 11.1 to use the latest features and to provide feedback for the next LTS release, scheduled for April 2020. Go here to download  link:/download/nb110/nb110.html[Apache NetBeans 11.0], the current LTS release.
+
+link:/download/nb111/nb111.html[Download, role="button success"]
 
 == Java EE
 

--- a/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
@@ -33,7 +33,7 @@ for important requirements for download pages for Apache projects.
 :toc-title:
 :icons: font
 
-Apache NetBeans 11.1 was released on July the 20th, 2019.
+Apache NetBeans 11.1 was released on July 22, 2019.
 See link:/download/nb111/index.html[Apache NetBeans 11.1 Features] for a full list of features.
 
 ////
@@ -47,6 +47,8 @@ Apache NetBeans 11.1 is available for download from your closest Apache mirror.
 link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-bin.zip[netbeans-11.1-bin.zip] (
 link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.sha512[SHA-512],
 link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.asc[PGP ASC])
+
+- Installers: Coming soon!
 
 - Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip] 
 (link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.sha512[SHA-512],

--- a/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
@@ -24,7 +24,7 @@ for important requirements for download pages for Apache projects.
 
 ////
 = Downloading Apache NetBeans 11.1 
-:jbake-type: page
+:jbake-type: page-noaside
 :jbake-tags: download
 :jbake-status: published
 :keywords: Apache NetBeans 11.1 Download
@@ -33,4 +33,59 @@ for important requirements for download pages for Apache projects.
 :toc-title:
 :icons: font
 
-Apache NetBeans 11.1 (work in progress).
+Apache NetBeans 11.1 was released on July the 20th, 2019.
+See link:/download/nb111/index.html[Apache NetBeans 11.1 Features] for a full list of features.
+
+////
+NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
+NOTE: It's mandatory to link against https://www.apache.org for the sums & keys. https is recommended.
+NOTE: It's NOT recommended to link to github.
+////
+Apache NetBeans 11.1 is available for download from your closest Apache mirror.
+
+- Binaries: 
+link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-bin.zip[netbeans-11.1-bin.zip] (
+link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.sha512[SHA-512],
+link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.asc[PGP ASC])
+
+- Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip] 
+(link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.sha512[SHA-512],
+link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.asc[PGP ASC])
+
+- Javadoc for this release is available at https://bits.netbeans.org/11.1/javadoc
+
+////
+NOTE: Using https below is highly recommended.
+////
+Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity]
+of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).
+The PGP keys used to sign this release are available link:https://www.apache.org/dist/netbeans/KEYS[here].
+
+
+== Building from source
+
+To build Apache NetBeans 11.1 from source you need:
+
+. Oracle's Java 8 or Open JDK v8.
+. Apache Ant 1.10 or greater (https://ant.apache.org).
+
+Once you have everything installed then:
+
+1. Unzip link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip]
+in a directory of your liking.
+2. `cd` to that directory, and then run `ant` to build the Apache NetBeans IDE.
+Once built you can run the IDE by typing `./nbbuild/netbeans/bin/netbeans`
+
+== Community approval
+
+As in any other Apache Project, the Apache NetBeans Community approved this release
+through the following voting processes in our link:/community/mailing-lists.html[mailing lists] :
+
+- link:https://lists.apache.org/thread.html/481ef107e6f5d8d6dfb35a831134bbbce3c6adb725e915ea8e5159d6@%3Cdev.netbeans.apache.org%3E[PMC vote]
+- link:https://lists.apache.org/thread.html/b5d559bf860a5e6f5a908afec791c07ef1e0d0d16e6c739c73c454d9@%3Cdev.netbeans.apache.org%3E[PMC vote result]
+
+== Earlier releases
+
+Please visit the link:/download/index.html[Apache NetBeans Download page]
+for further details.
+

--- a/netbeans.apache.org/src/content/index.asciidoc
+++ b/netbeans.apache.org/src/content/index.asciidoc
@@ -17,14 +17,14 @@
      under the License.
 ////
 = Welcome to Apache NetBeans
-:jbake-type: page-noaside
+:jbake-type: page-front
 :jbake-tags: main
 :jbake-status: published
-:keywords: My asciidoc keywords here!
+:keywords: Apache NetBeans
 :icons: font
 :description: Apache NetBeans
 :note: The 'hero' tags below enable the 'hero' area in the page.gsp template
-:hero.top: Version 11.0
+:hero.top: Version 11.1
 :hero.title: Apache NetBeans
 :hero.subtitle: Fits the Pieces Together
 
@@ -45,7 +45,7 @@ Apache NetBeans provides editors, wizards, and templates to help you create appl
 
 [.card.magenta]
 .icon:download[] Cross Platform
-Apache NetBeans can be link:/download/nb110/nb110.html[installed] on all operating systems that support Java, i.e, Windows, Linux, Mac OSX and BSD. Write Once, Run Anywhere, applies to NetBeans too. 
+Apache NetBeans can be link:/download/index.html[installed] on all operating systems that support Java, i.e, Windows, Linux, Mac OSX and BSD. Write Once, Run Anywhere, applies to NetBeans too. 
 
 [.card.green]
 .icon:users[] Join us

--- a/netbeans.apache.org/src/content/templates/menu.gsp
+++ b/netbeans.apache.org/src/content/templates/menu.gsp
@@ -34,7 +34,7 @@
             <li> <a href="https://blogs.apache.org/netbeans/">Blog</a></li>
             <li> <a href="/help/index.html">Get Help</a> </li>
             <li> <a href="/plugins/index.html">Plugins</a> </li>
-            <li> <a href="/download/nb110/nb110.html">Download</a> </li>
+            <li> <a href="/download/index.html">Download</a> </li>
         </ul>
     </div>
 </div>

--- a/netbeans.apache.org/src/content/templates/news.gsp
+++ b/netbeans.apache.org/src/content/templates/news.gsp
@@ -23,8 +23,8 @@
     <div class='grid-container'>
         <div class='cell'>
             <div class="annotation">Just released!</div>
-            <h1 syle='font-size: 2rem'>Apache NetBeans 11.0</h1>
-            <p><a class="button success" href="/download/nb110/nb110.html">Read more</a></p>
+            <h1 syle='font-size: 2rem'>Apache NetBeans 11.1</h1>
+            <p><a class="button success" href="/download/nb111/index.html">Find out more</a></p>
         </div>
     </div>
 </section>

--- a/netbeans.apache.org/src/content/templates/page-front.gsp
+++ b/netbeans.apache.org/src/content/templates/page-front.gsp
@@ -20,7 +20,7 @@
 */%>
 <%/*
 
-    page-noaside.gsp: A main area with no aside.
+    page-front.gsp: Front page layout.
 
 */%>
 <!doctype html>
@@ -28,11 +28,21 @@
     <%include "head.gsp"%>
     <body>
         <%include "menu.gsp"%>
-        <div class='grid-container main-content'>
-            <h1 class="sect0">${content.title}</h1>
-            ${content.body}
-            <%include "tools.gsp"%>
+        <%include "news.gsp"%>
+        <div class='grid-container'>
+          <div style='margin: 2rem 0' class='grid-x grid-margin-x align-middle'>
+            <div class='cell large-2 medium-3 small-5'><img src='/images/apache-netbeans.svg'></img></div>
+            <div class='cell large-10 medium-9 small-7'>
+                <h1>Apache NetBeans</h1>
+                <h2 style='color: #a1c535'>Fits the Pieces Together</h2>
+                <p>Development Environment, Tooling Platform and Application Framework.</p>
+            </div>
+          </div>
         </div>
+        <div class='grid-container'>
+          ${content.body}
+        </div>
+        <%include "tools.gsp"%>
         <%include "footer.gsp"%>
 
         <script src="/js/vendor/jquery-3.2.1.min.js"></script>

--- a/netbeans.apache.org/src/content/templates/slider.gsp
+++ b/netbeans.apache.org/src/content/templates/slider.gsp
@@ -46,11 +46,11 @@
               <div class='grid-container'>
                   <div class='cell'>
                       <div class='annotation'>Apache NetBeans Transition News</div>
-                      <h1>Apache NetBeans 11.0 Features</h1>
+                      <h1>Apache NetBeans 11.1 Features</h1>
                       <p>
                         JDK 12, Java EE, Gradle and more!
                       </p>
-                      <p><a class='button success' href="/download/nb110/index.html">Features</a></p>
+                      <p><a class='button success' href="/download/index.html">Features</a></p>
                   </div>
               </div>
           </section>
@@ -75,11 +75,11 @@
               <div class='grid-container'>
                   <div class='cell'>
                       <div class='annotation'>Apache NetBeans Transition News</div>
-                      <h1>Apache NetBeans 11.0 Released!</h1>
+                      <h1>Apache NetBeans 11.1 Released!</h1>
                       <p>
-                        Download Apache NetBeans 11.0 from an Apache mirror near you.
+                        Download Apache NetBeans 11.1 from an Apache mirror near you.
                       </p>
-                      <p><a class='button success' href="/download/nb110/nb110.html">Download</a></p>
+                      <p><a class='button success' href="/download/index.html">Download</a></p>
                   </div>
               </div>
           </section>


### PR DESCRIPTION
Additional structural and content changes for Apache NetBeans 11.1 release.

- Fleshed out NB 11.1 download page with links
- Changed main menu download link to /download
- Simplified main download page and added text from mailing list thread.
- Added archive and dev sections, and moved content from /download page on to respective index pages.
- added new front page template copied from existing but put news back for now or we have no reference to the release (something to review further)
- reverted page-noaside for other page use (NB 11.1 info and download)

I used official Apache release date (today), but we could change to announcement date if you want?

References to installers, Snap, etc. need adding in after merging this.

As an aside, can we make sure links are full paths but without domain?  Makes restructuring content a bit simpler and safer.