### PR TITLE
Fix the information about PHP 7.4

### DIFF
--- a/netbeans.apache.org/src/content/download/nb111/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb111/index.asciidoc
@@ -155,7 +155,9 @@ Other enhancements broadly related to the Java area are listed below.
 
 == Web Frontend: JavaScript/HTML5/PHP
 
-- PHP 7.4: link:https://github.com/apache/netbeans/pull/1199[https://github.com/apache/netbeans/pull/1199]
+PHP 7.4 is not supported completely yet.
+
+- PHP 7.4 (Only link:https://wiki.php.net/rfc/null_coalesce_equal_operator[Null Coalescing Assignment Operator]): link:https://github.com/apache/netbeans/pull/1199[https://github.com/apache/netbeans/pull/1199]
 - Jade template code completion: link:https://github.com/apache/netbeans/pull/1254[https://github.com/apache/netbeans/pull/1254]
 - Update PHP samples: link:https://github.com/apache/netbeans/pull/1183[https://github.com/apache/netbeans/pull/1183]
 


### PR DESCRIPTION
PHP 7.4 is not supported completely in NB11.1. 

We should fix this because there is incorrect information in https://www.infoq.com/news/2019/07/netbeans-11-apache/ .

cc: @tmysik 