### PR TITLE
Update notes on versions of JDK to build with

### DIFF
--- a/netbeans.apache.org/src/content/download/dev/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/dev/index.asciidoc
@@ -37,12 +37,12 @@ Please visit link:https://builds.apache.org/job/netbeans-linux/[https://builds.a
 You can of course build Apache NetBeans from source. To do so:
 
 . Clone the https://github.com/apache/netbeans GitHub repository.
-. Install Oracle's Java 8 or Open JDK v8.
+. Install Oracle's Java or Open JDK (v8, v11).
 . Install Apache Ant 1.10 or greater (https://ant.apache.org/).
 
 Once you're all set just enter the `netbeans` directory and type:
 
-- `ant` to build the Apache NetBeans IDE.
+- `ant` to build the Apache NetBeans IDE on JDK 8, on JDK 11 also type -Dpermit.jdk9.builds=true with the `ant` command.
   ** Once built, the IDE bits are placed in the `./nbbuild/netbeans` directory. You can run the IDE from within the `netbeans` directory by typing `./nbbuild/netbeans/bin/netbeans` on unixes (for Windows the command is equivalent).
 - `ant tryme` to run the Apache NetBeans IDE.
 


### PR DESCRIPTION
Mention JDK 11 with regards to building Netbeans, mention also the flag that needs to be enabled when using ant to build.
Have not tried to build with other, non-LTS, JDK, but if I can, will update this modification to reflect it.