### PR TITLE
CSS Source Maps

### DIFF
--- a/netbeans.apache.org/build.gradle
+++ b/netbeans.apache.org/build.gradle
@@ -24,7 +24,6 @@ buildscript {
 }
 apply from: file("gradle/utils.gradle")
 apply plugin: 'org.jbake.site'
-apply plugin: 'io.freefair.jsass-base'
 
 loadGlobals(globalsFile)
 
@@ -39,19 +38,28 @@ loadGlobals(globalsFile)
 //...this means in either the content or the assets folders, and this will be the
 //generatedAssetsDir and generatedContentDir
 
-task compileContentSass(type: io.freefair.gradle.plugins.jsass.SassCompile,
-    description: "Compiles the projects SaSS files to the build directory.",
+task copySCSSSources(type: Copy,
+    description: "Copies SCSS files for easier debugging",
     group: "Build") {
-    sourceDir = file("$contentDir/scss")
-    destinationDir = file("$generatedAssetDir/css")
-    // Compile netbeans.scss, which imports all requirements
-    includePaths = files(file("$contentDir/scss/netbeans.scss"))
-    // @TODO - source maps not currently working
-    omitSourceMapUrl = true
-    // Compress the generated CSS
-    outputStyle = io.bit3.jsass.OutputStyle.COMPRESSED
-    // Precission to 3 digits
-    precision = 3
+      from file("$contentDir/scss")
+      into file("$generatedAssetDir/css")
+      includeEmptyDirs false
+      filteringCharset 'UTF-8'
+      include "**/*.scss"
+}
+
+
+task compileContentSass(dependsOn: ["copySCSSSources"]) {
+    doLast {
+
+        File cssDirectory = file("$generatedAssetDir/css")
+        cssDirectory.mkdirs()
+
+        File scss = file("$generatedAssetDir/css/netbeans.scss")
+
+        // See buildSrc/src/main/groovy/CSSUtils.groovy
+        compileCSS(scss)
+    }
 }
 
 task preprocessContentAssets(type: Copy,
@@ -62,7 +70,7 @@ task preprocessContentAssets(type: Copy,
     filteringCharset 'UTF-8'
     includeEmptyDirs false
     
-    include "**/*.js", "**/*.css", "**/css/*.css", 
+    include "**/*.js", "**/*.css", "**/*.css.map", "**/css/*.css", 
         "dtds/**",
         "**/*.png", "**/*.gif",
         "**/*.jpeg", "**/*.jpg",
@@ -175,8 +183,9 @@ task preprocessContentTemplates(type: Copy,
 
 }
 
-task preprocessContent(dependsOn: ["compileContentSass",
+task preprocessContent(dependsOn: [
 "preprocessContentAssets",
+"compileContentSass",
 "preprocessContentStatics",
 "preprocessTemplates",
 "preprocessContentTemplates"],

--- a/netbeans.apache.org/buildSrc/build.gradle
+++ b/netbeans.apache.org/buildSrc/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     compile "org.gradle:gradle-base-services:${libs.gradle}"
     compile "org.gradle:gradle-logging:${libs.gradle}"
     compile "org.slf4j:slf4j-api:1.7.25"
+    // SCSS Compiler below
+    compile "org.sharegov:mjson:1.4.0"
+    compile "io.bit3:jsass:5.7.4"
     //we will do this this way as extendsFrom does not work across containers or something...
     compile buildscript.configurations.tomcat.allDependencies
     testCompile 'junit:junit:4.12'

--- a/netbeans.apache.org/buildSrc/src/main/groovy/CSSUtils.groovy
+++ b/netbeans.apache.org/buildSrc/src/main/groovy/CSSUtils.groovy
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import io.bit3.jsass.CompilationException;
+import io.bit3.jsass.Compiler;
+import io.bit3.jsass.Options;
+import io.bit3.jsass.importer.Importer;
+import io.bit3.jsass.importer.Import;
+import io.bit3.jsass.Output;
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.FileWriter
+import java.util.Arrays
+
+class CSSUtils {
+
+    static def compileSCSS(File netbeansSCSS) {
+
+        File scssDirectory = netbeansSCSS.getParentFile()
+
+        File cssFile = new File(scssDirectory, "netbeans.css");
+        File mapFile = new File(scssDirectory, "netbeans.css.map");
+
+        Compiler compiler = new Compiler()
+        Options options = new Options()
+
+        options.setSourceComments(false)
+        options.setSourceMapContents(false)
+        options.setSourceMapEmbed(false)
+        options.setIsIndentedSyntaxSrc(false)
+        options.setOmitSourceMapUrl(false)
+        options.setOutputStyle(io.bit3.jsass.OutputStyle.COMPRESSED)
+        options.setSourceMapFile(mapFile.toURI())
+        options.setPrecision(3)
+        options.setIncludePaths(Arrays.asList(netbeansSCSS))
+
+        Output cssOutput = compiler.compileFile(
+            netbeansSCSS.toURI(), 
+            cssFile.toURI(),
+            options)
+
+        PrintWriter pw = new PrintWriter(new FileWriter(cssFile))
+        pw.print(cssOutput.getCss())
+        pw.close()
+
+        PrintWriter sm = new PrintWriter(new FileWriter(mapFile))
+        sm.print(cssOutput.getSourceMap())
+        sm.close()
+
+    }
+
+}
+
+

--- a/netbeans.apache.org/gradle/deps.gradle
+++ b/netbeans.apache.org/gradle/deps.gradle
@@ -11,7 +11,6 @@ buildscript {
         sharedDependencies = {
             classpath "org.codehaus.groovy:groovy-all:${libs.groovy}"
             classpath "org.jbake:jbake-gradle-plugin:1.2.0"
-            classpath "io.freefair.gradle:jsass-gradle-plugin:0.6.0"
         }
         tomcatDependencies = {
             tomcat "org.apache.tomcat.embed:tomcat-embed-core:${libs.tomcat}"

--- a/netbeans.apache.org/gradle/utils.gradle
+++ b/netbeans.apache.org/gradle/utils.gradle
@@ -8,4 +8,5 @@ ext {
     loadGlobals = Utils.&loadGlobals
     mergeContentAndMetadata = Utils.&mergeContentAndMetadata
     createMergeData = Utils.&createMergeData
+    compileCSS = CSSUtils.&compileSCSS
 }


### PR DESCRIPTION
A Groovy task to compile SCSS with sourcemaps using "io.bit3:jsass:5.7.4".
This makes CSS debugging easier.
Tested with firefox & chromium