### PR TITLE
Move links, fix typo

### DIFF
--- a/netbeans.apache.org/src/content/community/index.asciidoc
+++ b/netbeans.apache.org/src/content/community/index.asciidoc
@@ -27,13 +27,13 @@
 
 == Stay Informed
 
-The Apache NetBeans Community uses the link:mailing-lists.html[mailing lists] as the primary source of comunication. . See how to stay informed and in touch with other NetBeans users and developers.
+The Apache NetBeans Community uses the link:mailing-lists.html[mailing lists] as the primary source of comunication. See how to stay informed and in touch with other NetBeans users and developers.
 
 == Participate
-We welcome link:/participate/index.html[all kind of contributions]. And there are many ways to contribute: see how you can participate in Apache NetBeans.
+We welcome all kind of contributions. link:/participate/index.html[See how you can participate in Apache NetBeans].
 
 == NetBeans Events
-NetBeans users and developers participate in link:events.html[different events]. See how this works.
+NetBeans users and developers participate in different events. link:events.html[See how this works].
 
 == Who We Are
 The Apache NetBeans source code was donated by Oracle to the link:https://www.apache.org[Apache Software Foundation] in 2016.


### PR DESCRIPTION
Move links to the actionable parts of sentences, e.g. "See ...".
Minor typo cleanup.