### PR TITLE
Remove Emilian from Commercial Support page

### DIFF
--- a/netbeans.apache.org/src/content/help/commercial-support.asciidoc
+++ b/netbeans.apache.org/src/content/help/commercial-support.asciidoc
@@ -36,12 +36,6 @@ Software Foundation.
 |====
 |Applicant Name|Skills|Details|Location|Contact details
 
-| Emilian Bold
-| Java Swing,NetBeans APIs, NetBeans Platform
-| Emilian Bold is a Java developer with a decade of experience in rich desktop applications, usually based on Swing and the NetBeans Platform. NetBeans Dream Team member. Apache committer. Emilian and his colleagues are available for work through his own company Joseki Bold SRL.
-| Timisoara, Romania
-| link:mailto:emi@apache.org[emi@apache.org], http://www.josekibold.ro/
-
 | Oliver Rettig
 | Java Swing,NetBeans APIs, NetBeans Platform
 | Oliver Rettig is a scientist in the field of motion analysis and a Java developer with a decade of experience in scientific desktop  application development, usually based on Swing and the NetBeans Platform (http://upperlimb.orat.de and  http://www.motion-science.org/). Oliver is available for work through his own company ORAT (http://www.orat.de).


### PR DESCRIPTION
Please remove my email from the Commercial Support page.

It seems that instead of being a page about Commercial Support it's a page where Commercial entities come for priority free support.