### PR TITLE
[NETBEANS-3209] Add JAVA_HOME and ANT_HOME note

### DIFF
--- a/netbeans.apache.org/src/content/download/dev/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/dev/index.asciidoc
@@ -39,6 +39,7 @@ You can of course build Apache NetBeans from source. To do so:
 . Clone the https://github.com/apache/netbeans GitHub repository.
 . Install Oracle's Java or Open JDK (v8, v11).
 . Install Apache Ant 1.10 or greater (https://ant.apache.org/).
+. Set JAVA_HOME and ANT_HOME appropriately or leave them undefined.
 
 Once you're all set just enter the `netbeans` directory and type:
 


### PR DESCRIPTION
Add a brief note about the JAVA_HOME and ANT_HOME environment variables
to the build instructions on the Web site and the GitHub repository. See
the following message on the mailing list for details:

Re: Building NetBeans 11.1 from source fails with compile errors
https://mail-archives.apache.org/mod_mbox/netbeans-dev/201910.mbox/%3C26c1f141-b021-4473-059f-41ec0b5e3613%40status6.com%3E

Fixes #3209
