### PR TITLE
[NETBEANS-3208] Add Snap package to download page

### DIFF
--- a/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
@@ -73,6 +73,7 @@ Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#
 of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).
 The PGP keys used to sign this release are available link:https://www.apache.org/dist/netbeans/KEYS[here].
 
+Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 
 == Deployment platforms
 


### PR DESCRIPTION
Add the snap package (https://snapcraft.io/netbeans) as an alternative
for Linux systems on the Apache NetBeans 11.1 download page.

Fixes #3208
