### PR TITLE
Update Ant build source instructions to use zip

### DIFF
--- a/netbeans.apache.org/src/content/download/dev/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/dev/index.asciidoc
@@ -43,9 +43,9 @@ You can of course build Apache NetBeans from source. To do so:
 
 Once you're all set just enter the `netbeans` directory and type:
 
-- `ant` to build the Apache NetBeans IDE on JDK 8, on JDK 11 also type -Dpermit.jdk9.builds=true with the `ant` command.
-  ** Once built, the IDE bits are placed in the `./nbbuild/netbeans` directory. You can run the IDE from within the `netbeans` directory by typing `./nbbuild/netbeans/bin/netbeans` on unixes (for Windows the command is equivalent).
-- `ant tryme` to run the Apache NetBeans IDE.
+- `ant build` to build the Apache NetBeans IDE on JDK 8, on JDK 11 also type -Dpermit.jdk9.builds=true with the `ant build` command.
+  ** This will build a binary zip bundle of the IDE at `./nbbuild/NetBeans-<version-hash>-release.zip`. Extract that zip in a place of your choosing and run `netbeans/bin/netbeans` (or `netbeans/bin/netbeans.exe` on Windows).
+- `ant tryme` to run the Apache NetBeans IDE directly from the build folder rather than the zip for development purposes.
 
 For details, go here: https://cwiki.apache.org/confluence/display/NETBEANS/Development+Environment
 


### PR DESCRIPTION
Change the Ant instructions to specify use of `ant build` rather than default `ant`. People wanting a binary closer to what is distributed should use the zip bundle, not the contents of `nbbuild/netbeans`