### PR TITLE
Complete update of website for release 11.2

### DIFF
--- a/netbeans.apache.org/src/content/download/archive/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/archive/index.asciidoc
@@ -29,6 +29,12 @@
 Older Apache NetBeans releases and pre-Apache NetBeans releases can still be
 downloaded, but are no longer supported.
 
+== Apache NetBeans 11 feature update 1 (NB 11.1)
+
+Apache NetBeans 11.1 was released on July 22, 2019.
+
+link:/download/nb111/index.html[Features, role="button"] link:/download/nb111/nb111.html[Download, role="button success"]
+
 == Apache NetBeans 10.0
 
 Apache NetBeans 10.0 was released on December 27, 2018.
@@ -47,6 +53,4 @@ link:/download/nb90/[Features, role="button"] link:/download/nb90/nb90.html[Down
 - https://netbeans.org/downloads/8.1/
 - https://netbeans.org/downloads/8.0/
 - https://netbeans.org/downloads/7.4/
-
-
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -39,15 +39,9 @@ features. See link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+
 
 == Apache NetBeans 11 feature update 2 (NB 11.2)
 
-Latest version of the IDE, released on October 31, 2019.
+Latest version of the IDE, released on October 25, 2019.
 
 link:/download/nb112/index.html[Features, role="button"] link:/download/nb112/nb112.html[Download, role="button success"]
-
-== Apache NetBeans 11 feature update 1 (NB 11.1)
-
-Latest version of the IDE, released on July 22, 2019.
-
-link:/download/nb111/index.html[Features, role="button"] link:/download/nb111/nb111.html[Download, role="button success"]
 
 == Apache NetBeans 11 LTS (NB 11.0)
 

--- a/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb111/nb111.asciidoc
@@ -44,25 +44,25 @@ NOTE: It's NOT recommended to link to github.
 Apache NetBeans 11.1 is available for download from your closest Apache mirror.
 
 - Binaries: 
-link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-bin.zip[netbeans-11.1-bin.zip] (
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.asc[PGP ASC])
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip[netbeans-11.1-bin.zip] (
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-bin.zip.asc[PGP ASC])
 
 - Installers:
  
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-windows-x64.exe[Apache-NetBeans-11.1-bin-windows-x64.exe] (
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-windows-x64.exe.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-windows-x64.exe.asc[PGP ASC])
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-linux-x64.sh[Apache-NetBeans-11.1-bin-linux-x64.sh] (
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-linux-x64.sh.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-linux-x64.sh.asc[PGP ASC])
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-macosx.dmg[Apache-NetBeans-11.1-bin-macosx.dmg] (
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-macosx.dmg.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-macosx.dmg.asc[PGP ASC])
+* link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-windows-x64.exe[Apache-NetBeans-11.1-bin-windows-x64.exe] (
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-windows-x64.exe.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-windows-x64.exe.asc[PGP ASC])
+* link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-linux-x64.sh[Apache-NetBeans-11.1-bin-linux-x64.sh] (
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-linux-x64.sh.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-linux-x64.sh.asc[PGP ASC])
+* link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-macosx.dmg[Apache-NetBeans-11.1-bin-macosx.dmg] (
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-macosx.dmg.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/Apache-NetBeans-11.1-bin-macosx.dmg.asc[PGP ASC])
 
-- Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip] 
-(link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.asc[PGP ASC])
+- Source: link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip] 
+(link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip.asc[PGP ASC])
 
 - Javadoc for this release is available at https://bits.netbeans.org/11.1/javadoc
 
@@ -71,7 +71,7 @@ NOTE: Using https below is highly recommended.
 ////
 Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity]
 of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).
-The PGP keys used to sign this release are available link:https://www.apache.org/dist/netbeans/KEYS[here].
+The PGP keys used to sign this release are available link:https://archive.apache.org/dist/netbeans/KEYS[here].
 
 Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 
@@ -84,12 +84,12 @@ Apache NetBeans 11.1 runs on JDK 8, 11, and 12.  (JDK 12 is the current JDK rele
 
 To build Apache NetBeans 11.1 from source you need:
 
-. Oracle's Java 8 or Open JDK v8.
+. Oracle's Java 8 or OpenJDK v8.
 . Apache Ant 1.10 or greater (https://ant.apache.org).
 
 Once you have everything installed then:
 
-1. Unzip link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip]
+1. Unzip link:https://archive.apache.org/dist/netbeans/netbeans/11.1/netbeans-11.1-source.zip[netbeans-11.1-source.zip]
 in a directory of your liking.
 2. `cd` to that directory, and then run `ant` to build the Apache NetBeans IDE.
 Once built you can run the IDE by typing `./nbbuild/netbeans/bin/netbeans`

--- a/netbeans.apache.org/src/content/download/nb112/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb112/index.asciidoc
@@ -36,6 +36,8 @@ Apache NetBeans 11.2 is the second Apache NetBeans release outside the Apache In
 
 TIP: The LTS release of the Apache NetBeans 11 cycle is Apache NetBeans 11.0. The 11.1 and 11.2 releases have not been tested as heavily as the LTS release and may therefore be less stable. Use 11.2 to use the latest features and to provide feedback for the next LTS release, scheduled for April 2020. Go here to download  link:/download/nb110/nb110.html[Apache NetBeans 11.0], the current LTS release.
 
+link:/download/nb112/nb112.html[Download, role="button success"]
+
 == Release Drivers
 
 === Java

--- a/netbeans.apache.org/src/content/download/nb112/nb112.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb112/nb112.asciidoc
@@ -33,7 +33,7 @@ for important requirements for download pages for Apache projects.
 :toc-title:
 :icons: font
 
-Apache NetBeans 11.2 was released on October 31, 2019.
+Apache NetBeans 11.2 was released on October 25, 2019.
 See link:/download/nb112/index.html[Apache NetBeans 11.2 Features] for a full list of features.
 
 ////
@@ -52,7 +52,17 @@ link:https://www.apache.org/dist/netbeans/netbeans/11.2/netbeans-11.2-bin.zip.as
 (link:https://www.apache.org/dist/netbeans/netbeans/11.2/netbeans-11.2-source.zip.sha512[SHA-512],
 link:https://www.apache.org/dist/netbeans/netbeans/11.2/netbeans-11.2-source.zip.asc[PGP ASC])
 
-- Installers: link:https://www.apache.org/dist/netbeans/netbeans/11.2/[installers for supported platforms]
+- Installers:
+ 
+* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-windows-x64.exe[Apache-NetBeans-11.2-bin-windows-x64.exe] (
+link:https://www.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-windows-x64.exe.sha512[SHA-512],
+link:https://www.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-windows-x64.exe.asc[PGP ASC])
+* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-linux-x64.sh[Apache-NetBeans-11.2-bin-linux-x64.sh] (
+link:https://www.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-linux-x64.sh.sha512[SHA-512],
+link:https://www.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-linux-x64.sh.asc[PGP ASC])
+* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-macosx.dmg[Apache-NetBeans-11.2-bin-macosx.dmg] (
+link:https://www.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-macosx.dmg.sha512[SHA-512],
+link:https://www.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-macosx.dmg.asc[PGP ASC])
 
 ////
 NOTE: Using https below is highly recommended.
@@ -71,15 +81,16 @@ Apache NetBeans 11.2 runs on JDK 8, 11, and 13.  (JDK 13 is the current JDK rele
 
 To build Apache NetBeans 11.2 from source you need:
 
-. Oracle's Java 8 or Open JDK v8.
+. Oracle's Java 8 or OpenJDK v8.
 . Apache Ant 1.10 or greater (https://ant.apache.org).
 
 Once you have everything installed then:
 
 1. Unzip link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.2/netbeans-11.2-source.zip[netbeans-11.2-source.zip]
 in a directory of your liking.
-2. `cd` to that directory, and then run `ant` to build the Apache NetBeans IDE.
-Once built you can run the IDE by typing `./nbbuild/netbeans/bin/netbeans`
+2. `cd` to that directory, and then run `ant build` to build the Apache NetBeans IDE.
+3. A zip of the IDE will be built inside `nbbuild`. Unzip this in a place of your choosing.
+4. Inside the unzipped IDE run `./bin/netbeans` (Linux / macOS) or `./bin/netbeans.exe` (Windows).
 
 == Community approval
 

--- a/netbeans.apache.org/src/content/templates/news.gsp
+++ b/netbeans.apache.org/src/content/templates/news.gsp
@@ -23,8 +23,8 @@
     <div class='grid-container'>
         <div class='cell'>
             <div class="annotation">Just released!</div>
-            <h1 syle='font-size: 2rem'>Apache NetBeans 11.1</h1>
-            <p><a class="button success" href="/download/nb111/index.html">Find out more</a></p>
+            <h1 syle='font-size: 2rem'>Apache NetBeans 11.2</h1>
+            <p><a class="button success" href="/download/nb112/index.html">Find out more</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
- change news header to point at new release
- update installer links to use mirrors
- change release date to official release date
- update build instructions
- move 11.1 to release archive page and change download links to use archive.apache.org