### PR TITLE
Fix markup that was breaking formatting for Quickstart: GUI page

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui.asciidoc
@@ -75,9 +75,6 @@ Alternatively, you can find a JFrame form by choosing New > Other > Swing GUI Fo
 The IDE creates the  ``ContactEditorUI``  form and the  ``ContactEditorUI``  class within the  ``ContactEditorUI.java``  application and opens the  ``ContactEditorUI``  form in the GUI Builder. Notice that the  ``my.contacteditor``  package replaces the default package.
 
  
-|===
-
-----
 
 <<top,top>>
 


### PR DESCRIPTION
Formatting on the QuickStart: GUI page is broken. Here's a quick fix.