### PR TITLE
migrate to downloads.apache.org -  missing apidoc link

### DIFF
--- a/netbeans.apache.org/src/content/download/maven/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/maven/index.asciidoc
@@ -81,7 +81,7 @@ If all mirrors are failing, there are <i>backup</i> mirrors (at the end of the m
 |===
 | | Links  | Checksum | Signature
 
-|Apache NetBeans parent pom 2 | link:++[preferred]netbeans/netbeans-parent/netbeans-parent-2/netbeans-parent-2-source-release.zip++[netbeans-parent-2-source-release.zip] | link:++https://www.apache.org/dist/netbeans/netbeans-parent/netbeans-parent-2/netbeans-parent-2-source-release.zip.sha512++[netbeans-parent-2-source-release.zip.sha512] | link:++https://www.apache.org/dist/netbeans/netbeans-parent/netbeans-parent-2/netbeans-parent-2-source-release.zip.asc++[netbeans-parent-2-source-release.zip.asc]
+|Apache NetBeans parent pom 2 | link:++[preferred]netbeans/netbeans-parent/netbeans-parent-2/netbeans-parent-2-source-release.zip++[netbeans-parent-2-source-release.zip] | link:++https://downloads.apache.org/netbeans/netbeans-parent/netbeans-parent-2/netbeans-parent-2-source-release.zip.sha512++[netbeans-parent-2-source-release.zip.sha512] | link:++https://downloads.apache.org/netbeans/netbeans-parent/netbeans-parent-2/netbeans-parent-2-source-release.zip.asc++[netbeans-parent-2-source-release.zip.asc]
 
 |===
 

--- a/netbeans.apache.org/src/content/download/nb110/nb110.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb110/nb110.asciidoc
@@ -46,20 +46,20 @@ NOTE: It's NOT recommended to link to github.
 Apache NetBeans 11.0 is available for download from your closest Apache mirror. For this release no official installers are provided, please just download the binaries and unzip them.
 
 - Source: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-source.zip[incubating-netbeans-11.0-source.zip] 
-(link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-source.zip.sha512[SHA-512],
-link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-source.zip.asc[PGP ASC])
+(link:https://downloads.apache.org/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-source.zip.sha512[SHA-512],
+link:https://downloads.apache.org/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-source.zip.asc[PGP ASC])
 
 - Binaries: 
 link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-bin.zip[incubating-netbeans-11.0-bin.zip] (
-link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-bin.zip.sha512[SHA-512],
-link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-bin.zip.asc[PGP ASC])
+link:https://downloads.apache.org/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-bin.zip.sha512[SHA-512],
+link:https://downloads.apache.org/incubator/netbeans/incubating-netbeans/incubating-11.0/incubating-netbeans-11.0-bin.zip.asc[PGP ASC])
 
 - Javadoc for this release is available at https://bits.netbeans.org/11.0/javadoc
 
 ////
 NOTE: Using https below is highly recommended.
 ////
-Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity] of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).  The PGP keys used to sign this release are available link:https://www.apache.org/dist/incubator/netbeans/KEYS[here].
+Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity] of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).  The PGP keys used to sign this release are available link:https://downloads.apache.org/incubator/netbeans/KEYS[here].
 
 TIP: Installers have been introduced for the first time in the next release, in Apache NetBeans 11.1. Go link:https://netbeans.apache.org/download/nb111/nb111.html[here] for details.
 

--- a/netbeans.apache.org/src/content/download/nb112/nb112.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb112/nb112.asciidoc
@@ -64,12 +64,14 @@ link:https://archive.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2
 link:https://archive.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-macosx.dmg.sha512[SHA-512],
 link:https://archive.apache.org/dist/netbeans/netbeans/11.2/Apache-NetBeans-11.2-bin-macosx.dmg.asc[PGP ASC])
 
+- Javadoc for this release is available at https://bits.netbeans.org/11.2/javadoc
+
 ////
 NOTE: Using https below is highly recommended.
 ////
 Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity]
 of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).
-The PGP signatures should be matched against the link:https://www.apache.org/dist/netbeans/KEYS[KEYS] file which contains the PGP keys used to sign this release.
+The PGP signatures should be matched against the link:https://downloads.apache.org/netbeans/KEYS[KEYS] file which contains the PGP keys used to sign this release.
 
 Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 

--- a/netbeans.apache.org/src/content/download/nb113/nb113.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb113/nb113.asciidoc
@@ -44,21 +44,23 @@ NOTE: It's NOT recommended to link to github.
 Apache NetBeans 11.3 is available for download from your closest Apache mirror.
 
 - Binaries: 
-link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/netbeans-11.3-bin.zip[netbeans-11.3-bin.zip] (link:https://www.apache.org/dist/netbeans/netbeans/11.3/netbeans-11.3-bin.zip.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.3/netbeans-11.3-bin.zip.asc[PGP ASC])
+link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/netbeans-11.3-bin.zip[netbeans-11.3-bin.zip] (link:https://downloads.apache.org/netbeans/netbeans/11.3/netbeans-11.3-bin.zip.sha512[SHA-512],
+link:https://downloads.apache.org/netbeans/netbeans/11.3/netbeans-11.3-bin.zip.asc[PGP ASC])
 
 - Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/netbeans-11.3-source.zip[netbeans-11.3-source.zip] 
-(link:https://www.apache.org/dist/netbeans/netbeans/11.3/netbeans-11.3-source.zip.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.3/netbeans-11.3-source.zip.asc[PGP ASC])
+(link:https://downloads.apache.org/netbeans/netbeans/11.3/netbeans-11.3-source.zip.sha512[SHA-512],
+link:https://downloads.apache.org/netbeans/netbeans/11.3/netbeans-11.3-source.zip.asc[PGP ASC])
 
 - Installers: 
 
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-windows-x64.exe[Apache-NetBeans-11.3-bin-windows-x64.exe] (link:https://www.apache.org/dist/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-windows-x64.exe.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-windows-x64.exe.asc[PGP ASC])
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-linux-x64.sh[Apache-NetBeans-11.3-bin-linux-x64.sh] (link:https://www.apache.org/dist/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-linux-x64.sh.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-linux-x64.sh.asc[PGP ASC])
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-macosx.dmg[Apache-NetBeans-11.3-bin-macosx.dmg] (link:https://www.apache.org/dist/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-macosx.dmg.sha512[SHA-512],
-link:https://www.apache.org/dist/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-macosx.dmg.asc[PGP ASC])
+* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-windows-x64.exe[Apache-NetBeans-11.3-bin-windows-x64.exe] (link:https://downloads.apache.org/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-windows-x64.exe.sha512[SHA-512],
+link:https://downloads.apache.org/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-windows-x64.exe.asc[PGP ASC])
+* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-linux-x64.sh[Apache-NetBeans-11.3-bin-linux-x64.sh] (link:https://downloads.apache.org/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-linux-x64.sh.sha512[SHA-512],
+link:https://downloads.apache.org/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-linux-x64.sh.asc[PGP ASC])
+* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-macosx.dmg[Apache-NetBeans-11.3-bin-macosx.dmg] (link:https://downloads.apache.org/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-macosx.dmg.sha512[SHA-512],
+link:https://downloads.apache.org/netbeans/netbeans/11.3/Apache-NetBeans-11.3-bin-macosx.dmg.asc[PGP ASC])
+
+- Javadoc for this release is available at https://bits.netbeans.org/11.3/javadoc
 
 TIP: The installers will not run under JDK 14 because usage is made of the Pack200 Tools and API, for packing and unpacking, which is removed in JDK 14, see link:https://openjdk.java.net/jeps/367[JEP 367].
 
@@ -67,7 +69,7 @@ NOTE: Using https below is highly recommended.
 ////
 Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity]
 of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).
-The PGP signatures should be matched against the link:https://www.apache.org/dist/netbeans/KEYS[KEYS] file which contains the PGP keys used to sign this release.
+The PGP signatures should be matched against the link:https://downloads.apache.org/netbeans/KEYS[KEYS] file which contains the PGP keys used to sign this release.
 
 Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 


### PR DESCRIPTION
direct link to KEYS, asc or sha512 should prefer downloads.apache.org (noticed on infra)
https://blogs.apache.org/infra/entry/more-secure-and-robust-downloads

the https://www.apache.org/dyn* url should be kept

Added apidoc 11.2 and 11.3

