### PR TITLE
Add link to NetCAT wiki page.

### DIFF
--- a/netbeans.apache.org/src/content/index.asciidoc
+++ b/netbeans.apache.org/src/content/index.asciidoc
@@ -53,7 +53,7 @@ Subscribe to our link:/community/mailing-lists.html[mailing lists], or follow us
 
 [.card.magenta]
 .icon:arrow-right[] Participate
-See how you can participate by link:/participate/submit-pr.html[submitting pull requests], or link:https://issues.apache.org/jira/projects/NETBEANS/summary[filing issues].
+See how you can participate by link:/participate/submit-pr.html[submitting pull requests], link:https://issues.apache.org/jira/projects/NETBEANS/summary[filing issues], or joining the link:https://cwiki.apache.org/confluence/display/NETBEANS/NetCAT[NetCAT] program.
 
 [.card.blue]
 .icon:book[] Learn


### PR DESCRIPTION
This will provide better visibility for the NetCAT program and make it easier for participants to sign up.