### PR TITLE
Changing location of Plugin Portal Update Center for NetBeans 12.0

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -12,7 +12,7 @@ Redirect 302 /nb/plugins/11.2/ http://plugins.netbeans.org/nbpluginportal/update
 Redirect 302 /nb/updates/11.3/ https://netbeans-vm.apache.org/uc/11.3/
 Redirect 302 /nb/plugins/11.3/ https://netbeans-vm.apache.org/pluginportal2/updates/11.0/
 Redirect 302 /nb/updates/12.0/ https://netbeans-vm.apache.org/uc/12.0/
-Redirect 302 /nb/plugins/12.0/ https://netbeans-vm.apache.org/pluginportal2/updates/11.0/
+Redirect 302 /nb/plugins/12.0/ https://plugins.netbeans.apache.org/data/12.0/
 Redirect 302 /nb/updates/dev/ https://netbeans-vm.apache.org/uc/11.3/
 Redirect 302 /nb/plugins/dev/ https://netbeans-vm.apache.org/pluginportal2/updates/11.0/
 Redirect 302 /nb/issues_redirect.html https://issues.apache.org/jira/projects/NETBEANS/issues


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/NETBEANSINFRA-185 to finally get rid of legacy Plugin Portal 2.0 which is hosted on Oracle infrastructure.