### PR TITLE
fixed step numbers and bullet appearance

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect.asciidoc
@@ -73,7 +73,7 @@ The FindBugs plugin should be downloaded and installed into the NetBeans IDE as 
 image::images/inspect-small.png[role="left", link="images/inspect.png"]
 
 --
-
+[start=3]
 . In the Installer dialog box, click Next to proceed with the installation.
 
 [.feature]
@@ -82,7 +82,7 @@ image::images/inspect-small.png[role="left", link="images/inspect.png"]
 image::images/plugin-small.png[role="left", link="images/plugin.png"]
 
 --
-
+[start=4]
 . Review the license agreement, select the license agreement option, and click Install.
 . When the installation is complete, click Finish.
 
@@ -115,7 +115,7 @@ image::images/allconfig-small.png[role="left", link="images/allconfig.png"]
 
 NOTE: You need to install the <<plugin,FindBugs>> plugin to run this configuration for the first time.
 
-
+[start=4]
 . Click Inspect.
 The results of the analysis are displayed in the Inspector Window as a tree view on the left.
 
@@ -157,7 +157,7 @@ The  ``NetBeans Java Hints``  configuration available in the IDE enables you to 
 
 NOTE: You can define a scope (a file, package, or project(s)) for the  ``NetBeans Java Hints``  configuration.
 
-
+[start=3]
 . Select the Configuration radio button and choose  ``NetBeans Java Hints``  in the drop-down list.
 
 [.feature]
@@ -167,13 +167,13 @@ image::images/hints-small.png[role="left", link="images/hints.png"]
 
 --
 
-
+[start=4]
 . Click Inspect.
 The IDE displays the tree view with the results of the analysis with the  ``NetBeans Java Hints``  configuration in the Inspector Window.
 
 image::images/hintsconfig.png[]
 
-
+[start=5]
 . In the Inspector Window, click the <<categorize,Categorize>> button in the toolbar on the left to view the problems grouped into categories.
 
 image::images/catview.png[]
@@ -207,7 +207,7 @@ NOTE: You need to install the <<plugin,FindBugs>> plugin to run this configurati
 
 NOTE: You can inspect a file, package, or project(s) with the  ``FindBugs``  configuration.
 
-
+[start=3]
 . In the Inspect dialog box, select the  ``FindBugs``  configuration.
 
 [.feature]
@@ -219,7 +219,7 @@ image::images/fb-small.png[role="left", link="images/fb.png"]
 
 
 
-
+[start=4]
 . Click the Inspect button to initiate the static code analysis.
 The result of the static code analysis is displayed in the Inspector Window below the Source Editor.
 The description of the selected bug is displayed in the frame on the right.
@@ -231,7 +231,7 @@ image::images/inspector-small.png[role="left", link="images/inspector.png"]
 
 --
 
-
+[start=5]
 . Alternatively, click the <<categorize,Categorize>> button in the toolbar on the left to view the bugs grouped into categories.
 
 image::images/fbcat.png[]
@@ -261,7 +261,7 @@ image::images/fb-editor-small.png[role="left", link="images/fb-editor.png"]
 
 --
 
-
+[start=4]
 . Select the Run FindBugs in Editor option.
 . Click OK.
 If you now press kbd:[Alt+Enter] in the source code where a bug is reported and click the black arrow pointing to the right at the end of the displayed tip, the IDE shows some fixing options for a potential bug.
@@ -287,7 +287,7 @@ The IDE displays the Configurations dialog box.
 
 image::images/configurations-db.png[]
 
-
+[start=4]
 . Ensure  ``Default``  is selected in the Configurations drop-down list.
 . In the Analyzer drop-down list, select the  ``JRE 8 Profiles Conformance`` ,  ``Netbeans Java Hints`` , or  ``FindBugs``  analyzer.
 . Depending on the choice of the analyzer in the previous step, select the profile to validate, the inspections, or bugs you need to include into your  ``Default``  configuration.
@@ -299,7 +299,7 @@ image::images/select-inspections-small.png[role="left", link="images/select-insp
 
 --
 
-
+[start=7]
 . Click OK to save your  ``Default``  configuration.
 
 == Creating and Deleting Configurations
@@ -319,7 +319,7 @@ A  ``newConfig``  configuration is created and added to the Configurations drop-
 
 image::images/newconfig-created.png[]
 
-
+[start=5]
 . In the Analyzer drop-down list, choose  ``JRE 8 Profiles Conformance`` ,  ``Netbeans Java Hints`` , or  ``FindBugs`` .
 . Specify the profile, inspections, or bugs to be included into your own configuration.
 . Click OK to save your edits and close the Configurations dialog box.
@@ -345,7 +345,7 @@ image::images/renamedconfig.png[]
 
 image::images/delete.png[]
 
-
+[start=5]
 . In the Delete Configuration dialog box, click Yes to confirm the deletion of the configuration.
 
 image::images/delete-confirm.png[]
@@ -363,7 +363,8 @@ You can inspect your code for a particular deficiency in your source code using 
 . Choose Source > Inspect from the main IDE's menu.
 . In the Scope drop-down list of the Inspect dialog box, select a file, package, or project(s) to be inspected.
 . Select Single Inspection and do either of the following:
-* In the Single Inspection drop-down list, scroll and select a _single_ NetBeans Java hint or FindBugs bug to be used in the source code analysis.
+--
+* In the Single Inspection drop-down list, scroll and select a _single_ NetBeans Java hint or FindBugs bug to be used in the source code analysis, or
 
 [.feature]
 --
@@ -381,10 +382,11 @@ image::images/hint-inspection-small.png[role="left", link="images/hint-inspectio
 
 --
 
-
+[start=4]
 . In the Inspect dialog box, click Inspect to perform the source code analysis. 
 After the Inspect operation is completed, the hints that can be applied to your code or bugs that have been found are displayed in the Inspector Window below the Source Editor.
 
+--
 == Summary
 
 This tutorial covers most frequent usages of the static code analysis feature in the NetBeans IDE. Please note that with the static code analysis functionality you can also perform custom refactorings at a project scope, or apply particular refactoring configurations to several projects open in the IDE, etc.


### PR DESCRIPTION
I couldn't figure out the correct syntax to get the list items to be at level 2 to be indented under step 3 of "Running Single Inspections" so both are currently level 1 (solid bullet) so that they are obviously of the same level rather than one being empty and one filled. I use InDesign and FrameMaker normally and need to figure out Asciidoc . Sorry.