### PR TITLE
Move dev uc to 12.0

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -14,7 +14,7 @@ Redirect 302 /nb/plugins/11.3/ https://netbeans-vm.apache.org/pluginportal2/upda
 Redirect 302 /nb/updates/12.0/ https://netbeans-vm.apache.org/uc/12.0/
 Redirect 302 /nb/plugins/12.0/ https://plugins.netbeans.apache.org/data/12.0/
 Redirect 302 /nb/updates/dev/ https://netbeans-vm.apache.org/uc/11.3/
-Redirect 302 /nb/plugins/dev/ https://netbeans-vm.apache.org/pluginportal2/updates/11.0/
+Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/12.0/
 Redirect 302 /nb/issues_redirect.html https://issues.apache.org/jira/projects/NETBEANS/issues
 Redirect 302 /nb/report-issue https://issues.apache.org/jira/projects/NETBEANS/issues
 #cgi mirror script


### PR DESCRIPTION
I noticed, that the backends for updatecenter redirects for dev still point to 11.3. Given, that 12.0 is about to be released and from my perspective netbeans dev should pair with the newest plugins, I suggest to switch the update center urls over.