### PR TITLE
Add workaround for Apache NetBeans failing to run on macOS Big Sur.

### DIFF
--- a/netbeans.apache.org/src/content/download/nb121/nb121.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb121/nb121.asciidoc
@@ -75,6 +75,25 @@ The PGP keys used to sign this release are available link:https://archive.apache
 
 Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 
+
+== Known issue on macOS Big Sur 
+
+Apache NetBeans 12.1 fails to run on Big Sur. 
+
+Workaround: edit `netbeans.conf` and uncomment and set the JDK home path in the `netbeans_jdkhome` variable.
+
+----
+% ls /Library/Java/JavaVirtualMachines 
+adoptopenjdk-11.jdk	adoptopenjdk-8.jdk
+
+% sudo vi /Applications/NetBeans/Apache\ NetBeans\ 12.1.app/Contents/Resources/NetBeans/netbeans/etc/netbeans.conf
+----
+
+
+----
+netbeans_jdkhome="/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home"
+----
+
 == Deployment platforms
 
 Apache NetBeans 12.1 runs on JDK LTS releases 8 and 11, as well as on JDK 14, i.e., the current JDK release at the time of this NetBeans release.
@@ -108,4 +127,3 @@ through the following voting processes in our link:/community/mailing-lists.html
 
 Please visit the link:/download/index.html[Apache NetBeans Download page]
 for further details.
-


### PR DESCRIPTION
Apache NetBeans will not start on macOS Big Sur.

The issue is in the nbexec script.

`/usr/libexec/java_home` changed in Big Sur and fails to find the JDK when the `--failfast` parameter is used with the `+` sign in the `-v 1.8.0+` parameter. 

The easiest workaround is to manually set `netbeans_jdkhome` in `netbeans.conf`

https://stackoverflow.com/questions/tagged/netbeans+macos-big-sur

https://dev.to/pablohs1986/macos-users-java-problems-in-big-sur-help-7pa

