### PR TITLE
Add a Developing NetBeans section

### DIFF
--- a/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
+++ b/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
@@ -58,7 +58,7 @@ We appreciate new contributors to adhere to the following guidelines, to make th
 . Try to keep the code *readable, maintainable, easy to debug* and *performant*.
 
 == Learn to run and debug NetBeans IDE or Platform applications
-link:/participate/build-run-debug-tutorials.html[Watch a series of 5 short videos] (2 minutes on average) showing how to build, run and debug the NetBeans IDE or any NetBeans platform application from sources. 
+link:/participate/build-run-debug-tutorials.html[Watch a series of 5 short videos] (2 minutes on average) or see link:#develop[Developing NetBeans with NetBeans] for help on how to build, run and debug the NetBeans IDE or any NetBeans platform application from sources. 
 
 == Contributing to Apache NetBeans in GitHub
 
@@ -69,6 +69,21 @@ fork https://github.com/apache/netbeans in GitHub, this is done using
 the "fork" button on the top right of the GitHub page.
 
 You then need to clone the forked repository in your computer.
+
+[source, shell]
+----
+cd <your-project-dir>
+git clone https://github.com/<your-username>/netbeans.git
+----
+
+At this stage it is a good idea to check that you can build and run NetBeans.
+
+[source, shell]
+----
+cd netbeans
+ant
+ant tryme
+----
 
 Finally, in your computer, you need to setup your name and email in GitHub.
 This will also help git to rebase in order to fulfill its task.
@@ -134,6 +149,53 @@ If the PR is merged into master as-is then all these commits will be in the mast
 https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
 
 After submission (and certainly after someone starts reviewing the PR) you shouldn't touch the PR's history. 
+
+[[develop]]
+== Developing NetBeans with NetBeans
+These steps assume you have already forked, cloned and configured your NetBeans development repository.
+
+. Configure NetBeans
+  * Open your currently installed NetBeans
+  * Enable the _Developing NetBeans_ plugin.
+    ** Open the _Plugins_ dialog (_Tools->Plugins_)
+    ** Find _Developing NetBeans_ in either the _Available_ or _Installed_ list
+    ** If it is _Available_ select its checkbox and click _Install_
+    ** If it is _Installed_ but not _Active_, select its checkbox and click _Activate_
+
+. Add your development repository as a NetBeans Platform
+  * Open the _NetBeans Platform Manager_ (_Tools->NetBeans Platforms_)
+  * Click _Add Platform ..._
+  * Navigate to `<your-project-dir>/netbeans/nbbuild/` and select `netbeans`
+  * Click _Next >_
+  * Click _Finish_
+  * Select the _Sources_ tab
+  * Click _Add ZIP/Folder ..._
+  * Select `<your-project-dir>/netbeans` and click _Open_
+  * Close _NetBeans Platform Manager_
+
+. Create a new project (_File->New Project..._)
+  * In _Categories:_ select _Java with Ant / NetBeans Modules_
+  * In _Projects:_ select _Module Suite_
+  * Click _Next >_
+  * Enter a _Project Name:_ (e.g. NB-IDE-DEV)
+  * Optionally change the _Project Location:_
+  * Click _Finish_
+
+. Locate the source code for your development repository
+  * Open the _Favorites_ window (_Window->Favorites_)
+  * Select _Add to Favorites..._ in the right-click context menu
+  * Select `<your-project-dir>/netbeans` and click _Add_
+
+. Set a breakpoint in the source code. As a start try the entry point `public static void main (String args[])`
+  * In the _Favorites_ tab navigate to `platform/o.n.bootstrap/src/org/netbeans` and open `Main.java`
+  * Set a breakpoint
+
+. Start the debugger
+  * Select your IDE project (e.g. NB-IDE-DEV) from the _Run->Set Main Project_ menu
+  * Start the debugger :
+    ** _Debug->Debug Main Project_ menu,
+    ** *or* Click the Debug toolbar item
+    ** *or* Ctrl+F5
 
 [[donating-code]]
 == Donating Code


### PR DESCRIPTION
This PR adds the instructions described in 
https://lists.apache.org/thread.html/r45e7c6847056ef8f170f6aa5b7b81fca1e5ef87dcf05883178554b94%40%3Cdev.netbeans.apache.org%3E
to the Contributing Code page.

This is intended to complement the existing tutorial videos.
