### PR TITLE
Filing issues link changed to dedicated page

### DIFF
--- a/netbeans.apache.org/src/content/index.asciidoc
+++ b/netbeans.apache.org/src/content/index.asciidoc
@@ -53,7 +53,7 @@ Subscribe to our link:/community/mailing-lists.html[mailing lists], or follow us
 
 [.card.magenta]
 .icon:arrow-right[] Participate
-See how you can participate by link:/participate/submit-pr.html[submitting pull requests], link:https://issues.apache.org/jira/projects/NETBEANS/issues[filing issues], or joining the link:https://cwiki.apache.org/confluence/display/NETBEANS/NetCAT[NetCAT] program.
+See how you can participate by link:/participate/submit-pr.html[submitting pull requests], link:participate/report-issue.html[filing issues], or joining the link:https://cwiki.apache.org/confluence/display/NETBEANS/NetCAT[NetCAT] program.
 
 [.card.blue]
 .icon:book[] Learn


### PR DESCRIPTION
"Filing issues" link changed from direct link to JIRA to "Reporting issues" page.
This leads visitor to page where he can get more info how to report issue.