### PR TITLE
[NETBEANS-5420] RedirectMatch fix?

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -42,7 +42,7 @@ RedirectMatch 301 ^/features/cpp.*$ /kb/docs/cnd/
 Redirect 301 /java-on-client/java-me.html /kb/docs/mobility.html
 Redirect 301 /community/releases/82/ /download/archive/index.html
 RedirectMatch 301 ^/community/releases/.*$ /download/archive/index.html
-RedirectMatch 301 ^/downloads/.*$ /download/index.html
+RedirectMatch 301 ^/.?downloads/.*$ /download/index.html
 
 # A simple error page
 ErrorDocument 404 /404.html


### PR DESCRIPTION
netbeans.org redirection in netbeans-vm1 is sending us a spurious "/".