### PR TITLE
Some post-release changes for NB 12.3

### DIFF
--- a/netbeans.apache.org/src/content/download/nb120/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb120/index.asciidoc
@@ -33,7 +33,7 @@
 
 Welcome to Apache NetBeans 12.0!
 
-TIP: The LTS release of the Apache NetBeans 12 cycle is Apache NetBeans 12.0, which consolidates the feature releases link:http://netbeans.apache.org/download/nb111/index.html[11.1], link:http://netbeans.apache.org/download/nb112/index.html[11.2], and link:http://netbeans.apache.org/download/nb113/index.html[11.3]. Feature releases have not been tested as heavily as the LTS release, which passes through the link:https://cwiki.apache.org/confluence/display/NETBEANS/Results+from+Apache+NetBeans+IDE+12.0+Community+Acceptance+survey[NetCAT Community Acceptance process] and is for these reasons the annual major release. For details, see the link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[Apache NetBeans quarterly release cycle].
+TIP: The LTS release of the Apache NetBeans 12 cycle is Apache NetBeans 12.0, which consolidates the feature releases link:http://netbeans.apache.org/download/nb111/index.html[11.1], link:http://netbeans.apache.org/download/nb112/index.html[11.2], and link:http://netbeans.apache.org/download/nb113/index.html[11.3]. Feature releases have not been tested as heavily as the LTS release, which passes through the link:https://cwiki.apache.org/confluence/display/NETBEANS/Results+from+Apache+NetBeans+IDE+12.0+Community+Acceptance+survey[NetCAT Community Acceptance process]. For details, see the link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[Apache NetBeans quarterly release cycle].
 
 link:/download/nb120/nb120.html[Download, role="button success"]
 

--- a/netbeans.apache.org/src/content/download/nb122/nb122.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb122/nb122.asciidoc
@@ -44,20 +44,20 @@ NOTE: It's NOT recommended to link to github.
 Apache NetBeans 12.2 is available for download from your closest Apache mirror.
 
 - Binaries: 
-link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.2/netbeans-12.2-bin.zip[netbeans-12.2-bin.zip] (link:https://downloads.apache.org/netbeans/netbeans/12.2/netbeans-12.2-bin.zip.sha512[SHA-512],
-link:https://downloads.apache.org/netbeans/netbeans/12.2/netbeans-12.2-bin.zip.asc[PGP ASC])
+link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-bin.zip[netbeans-12.2-bin.zip] (link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-bin.zip.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-bin.zip.asc[PGP ASC])
 
 - Installers:
  
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-windows-x64.exe[Apache-NetBeans-12.2-bin-windows-x64.exe] (link:https://downloads.apache.org/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-windows-x64.exe.sha512[SHA-512],
-link:https://downloads.apache.org/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-windows-x64.exe.asc[PGP ASC])
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-linux-x64.sh[Apache-NetBeans-12.2-bin-linux-x64.sh] (link:https://downloads.apache.org/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-linux-x64.sh.sha512[SHA-512],
-link:https://downloads.apache.org/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-linux-x64.sh.asc[PGP ASC])
-* link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-macosx.dmg[Apache-NetBeans-12.2-bin-macosx.dmg] (link:https://downloads.apache.org/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-macosx.dmg.sha512[SHA-512],
-link:https://downloads.apache.org/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-macosx.dmg.asc[PGP ASC])
+* link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-windows-x64.exe[Apache-NetBeans-12.2-bin-windows-x64.exe] (link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-windows-x64.exe.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-windows-x64.exe.asc[PGP ASC])
+* link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-linux-x64.sh[Apache-NetBeans-12.2-bin-linux-x64.sh] (link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-linux-x64.sh.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-linux-x64.sh.asc[PGP ASC])
+* link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-macosx.dmg[Apache-NetBeans-12.2-bin-macosx.dmg] (link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-macosx.dmg.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/12.2/Apache-NetBeans-12.2-bin-macosx.dmg.asc[PGP ASC])
 
-- Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.2/netbeans-12.2-source.zip[netbeans-12.2-source.zip] (link:https://downloads.apache.org/netbeans/netbeans/12.2/netbeans-12.2-source.zip.sha512[SHA-512],
-link:https://downloads.apache.org/netbeans/netbeans/12.2/netbeans-12.2-source.zip.asc[PGP ASC])
+- Source: link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-source.zip[netbeans-12.2-source.zip] (link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-source.zip.sha512[SHA-512],
+link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-source.zip.asc[PGP ASC])
 
 - Javadoc for this release is available at https://bits.netbeans.org/12.2/javadoc
 
@@ -86,7 +86,7 @@ To build Apache NetBeans 12.2 from source you need:
 
 Once you have everything installed then:
 
-1. Unzip link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.2/netbeans-12.2-source.zip[netbeans-12.2-source.zip]
+1. Unzip link:https://archive.apache.org/dist/netbeans/netbeans/12.2/netbeans-12.2-source.zip[netbeans-12.2-source.zip]
 in a directory of your liking.
 
 [start=2]

--- a/netbeans.apache.org/src/content/download/nb123/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb123/index.asciidoc
@@ -33,7 +33,7 @@
 
 Welcome to Apache NetBeans 12.3, the third feature release of the Apache NetBeans 12 cycle!
 
-TIP: The LTS release of the Apache NetBeans 12 cycle is Apache NetBeans 12.0. The 12.3 release has not been tested as heavily as the LTS release and may therefore be less stable. Use 12.3 to use the latest features and to provide feedback for the next LTS release, scheduled for 2021. Go here to download  link:/download/nb120/nb120.html[Apache NetBeans 12.0], the current LTS release.
+TIP: The LTS release of the Apache NetBeans 12 cycle is Apache NetBeans 12.0. The 12.3 release has not been tested as heavily as the LTS release and may therefore be less stable. Use 12.3 to use the latest features and to provide feedback for the next LTS release. Go here to download  link:/download/nb120/nb120.html[Apache NetBeans 12.0], the current LTS release.
 
 link:/download/nb123/nb123.html[Download, role="button success"]
 

--- a/netbeans.apache.org/src/content/download/nb123/nb123.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb123/nb123.asciidoc
@@ -58,7 +58,7 @@ link:https://downloads.apache.org/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bi
 - Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.3/netbeans-12.3-source.zip[netbeans-12.3-source.zip] (link:https://downloads.apache.org/netbeans/netbeans/12.3/netbeans-12.3-source.zip.sha512[SHA-512],
 link:https://downloads.apache.org/netbeans/netbeans/12.3/netbeans-12.3-source.zip.asc[PGP ASC])
 
-- Javadoc for this release is available at https://bits.netbeans.org/12.2/javadoc
+- Javadoc for this release is available at https://bits.netbeans.org/12.3/javadoc
 
 ////
 NOTE: Using https below is highly recommended.


### PR DESCRIPTION
Fix Javadoc link. Change links to NB 12.2 ready for archiving. Remove references to LTS being annual / in 2021.