### PR TITLE
Fix bad code fence in Asciidoc for Nodes tutorial

### DIFF
--- a/netbeans.apache.org/src/content/tutorials/nbm-nodesapi2.asciidoc
+++ b/netbeans.apache.org/src/content/tutorials/nbm-nodesapi2.asciidoc
@@ -335,7 +335,7 @@ import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.util.ImageUtilities;
 import org.openide.util.lookup.Lookups;
-```
+----
 
 
 [start=3]


### PR DESCRIPTION
Fixes a bad closing code fence in a page in the Nodes tutorial.

Without this, the rendered page breaks like this:

![image](https://user-images.githubusercontent.com/2618447/110963824-88aa8200-8320-11eb-8b3e-c3bfb9f8e811.png)
