### PR TITLE
fix "Open Jira" button style on the Reporting issues page

### DIFF
--- a/netbeans.apache.org/src/content/participate/report-issue.asciidoc
+++ b/netbeans.apache.org/src/content/participate/report-issue.asciidoc
@@ -24,6 +24,7 @@
 :description: Apache NetBeans Reporting Issues
 :toc: left
 :toc-title:
+:linkattrs:
 
 If you have found a bug in the application, please help Apache NetBeans by reporting this problem to our bug tracking system. Click View Data button, copy the exception and submit it together with detailed information about what you were trying to achieve before the problem occurred. NetBeans uses the link:https://issues.apache.org/jira/projects/NETBEANS/issues[JIRA] issue tracking system; you must have a login to file a new issue. Just click "Log In" in the upper-right of the page to create one. Once you are logged in, you will see a red "Create" button at the top of the page.
 


### PR DESCRIPTION
Without this it wasn't displayed as a green button but as a text link with words "button success" visible on the website