### PR TITLE
NETBEANS-5444 add Usage Data Tracking page linked from NB

### DIFF
--- a/netbeans.apache.org/src/content/about/usage-tracking.asciidoc
+++ b/netbeans.apache.org/src/content/about/usage-tracking.asciidoc
@@ -1,0 +1,44 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= NetBeans Usage Data Tracking
+:jbake-type: page
+:jbake-tags: about
+:jbake-status: published
+:keywords: Apache NetBeans Usage Data Tracking
+:description: Apache NetBeans Usage Data Tracking
+
+The goal of usage data tracking is to collect and analyze statistical information about high-level features NetBeans users use. A better understanding which are the most and least frequently used features helps us better plan and design future releases. The collected data is strictly anonymous and it is sent to the netbeans.org server automatically. The data collection and submission have no performance impact and do not affect regular work flow.
+
+== What kind of usage data is being collected
+- IDE configuration - build number, OS info, list of enabled plug-ins
+- Use of project types (e.g. Java SE, Java SE Freeform, Java Web Application, Java Enterprise Application, Ruby / Rails Application, PHP, C/{cpp}, NB Module project, etc.)
+- Use of web application frameworks (e.g. Struts, JSF, Visual JSF, Spring, Hibernate, etc.)
+- Types and versions of servers and runtimes used for deployment (e.g. GlassFish, Tomcat, WebSphere, JBoss, WebLogic, WEBrick, etc.)
+- Types of JDBC drivers used for connections to databases (e.g. MySQL, JavaDB, Oracle, etc.)
+- Use of specific productivity features (e.g. Debugger, Profiler, GUI Builder)
+- Types of version control systems used by users (CVS, Subversion, Mercurial, ClearCase, etc.)
+- Accesses to Help topics.
+
+== What data is NOT being collected
+- User names and passwords.
+- Paths, filenames and class names.
+- Fragments of user's source code.
+
+The NetBeans team really appreciates your participation in the Usage data tracking program!
+


### PR DESCRIPTION
If this goes right it should be available at:
https://netbeans.apache.org//about/usage-tracking.html
which is linked from NB from a window asking you if you agree with the usage statistics collection. (see NETBEANS-5444)

I took the content from Google cache of the original page on netbeans.org - is that ok?


