### PR TITLE
[NETBEANS-5481] add note for Swift 5 runtime on macOS < 10.14.4

### DIFF
--- a/netbeans.apache.org/src/content/download/nb123/nb123.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb123/nb123.asciidoc
@@ -55,6 +55,8 @@ link:https://downloads.apache.org/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bi
 * link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-macosx.dmg[Apache-NetBeans-12.3-bin-macosx.dmg] (link:https://downloads.apache.org/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-macosx.dmg.sha512[SHA-512],
 link:https://downloads.apache.org/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-macosx.dmg.asc[PGP ASC])
 
+IMPORTANT: macOS versions prior to 10.14.4 require the link:https://support.apple.com/kb/dl1998?locale=en_US[Swift 5 Runtime] to be installed to launch Apache NetBeans 12.3.
+
 - Source: link:https://www.apache.org/dyn/closer.cgi/netbeans/netbeans/12.3/netbeans-12.3-source.zip[netbeans-12.3-source.zip] (link:https://downloads.apache.org/netbeans/netbeans/12.3/netbeans-12.3-source.zip.sha512[SHA-512],
 link:https://downloads.apache.org/netbeans/netbeans/12.3/netbeans-12.3-source.zip.asc[PGP ASC])
 
@@ -74,7 +76,7 @@ Apache NetBeans can also be installed as a self-contained link:https://snapcraft
 
 Apache NetBeans 12.3 runs on JDK LTS releases 8 and 11, as well as on JDK 15, i.e., the current JDK release at the time of this NetBeans release.
 
-TIP: The current JDKs have an issue on Mac OS Big Sur, that causes freezes on dialogs. That could be fixed by applying the workaround described at link:https://issues.apache.org/jira/browse/NETBEANS-5037?focusedCommentId=17234878&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17234878[NETBEANS-5037] .
+TIP: The current JDKs have an issue on macOS Big Sur, that causes freezes on dialogs. That could be fixed by applying the workaround described at link:https://issues.apache.org/jira/browse/NETBEANS-5037?focusedCommentId=17234878&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17234878[NETBEANS-5037] .
 
 == Building from Source
 


### PR DESCRIPTION
Adds a note to the 12.3 download page indicating that the Swift 5 runtime is needed to launch 12.3 on macOS versions prior to 10.14.4