### PR TITLE
make asfyaml file available on publish branch

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -106,6 +106,8 @@ cp -R ../master-branch/netbeans.apache.org/src/content/.htaccess content
 echo "Copying wiki/.htaccess..."
 cp -R ../master-branch/netbeans.apache.org/src/content/wiki/.htaccess content/wiki
 echo "All files copied"
+cp  ../master-branch/.asf.yaml .
+echo "Copying asf yaml file to publish branch"
 
 '''
                 }


### PR DESCRIPTION
Hi @vieiro, was missing the fact that asf.yaml has to be on the publish branch.

Hope this change make us reach the green lines