### PR TITLE
Include 3 columns in all 3 column tables

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/cnd/toolchain.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/toolchain.asciidoc
@@ -388,17 +388,17 @@ For the scheme of all supported tags and attributes of toolchain xml files, you 
 |===
 |Tags |Attributes |Description 
 
-|toolchain |Name of tool collection 
+|toolchain |Name of tool collection |
 
-|name |Name of tool collection 
+|name |Name of tool collection |
 
-|display |Display name of tool collection 
+|display |Display name of tool collection |
 
-|family |Group name of tool collection 
+|family |Group name of tool collection |
 
-|platforms |Supported platforms 
+|platforms |Supported platforms |
 
-|stringvalue |List of supported platforms separated by comma.
+|stringvalue |List of supported platforms separated by comma. |
 Possible values are:
 
 * linux
@@ -410,45 +410,45 @@ Possible values are:
 * none
  
 
-|makefile_writer |Custom makefile writer. 
+|makefile_writer |Custom makefile writer. |
 
 |class |Class name of custom makefile writer. It should implement
-org.netbeans.modules.cnd.makeproject.spi.configurations.MakefileWriter. 
+org.netbeans.modules.cnd.makeproject.spi.configurations.MakefileWriter. |
 
-|drive_letter_prefix |Special prefix for file names 
+|drive_letter_prefix |Special prefix for file names |
 
 |stringvalue |"/" for unix
-"/cygdrive/" for cygwin on Windows 
+"/cygdrive/" for cygwin on Windows |
 
 |base_folders |Container for base_folder tags. 
-One or more base_folder tags are contained in one base_folders tag. 
+One or more base_folder tags are contained in one base_folders tag. |
 
 |base_folder |Description of base directory for compilers.
-This tag can contain the following tags: 
+This tag can contain the following tags: |
 
-|regestry |Windows registry key of the tool. Note that the XML tag must be spelled "regestry" although this is a mispelling. 
+|regestry |Windows registry key of the tool. Note that the XML tag must be spelled "regestry" although this is a mispelling. |
 
-|pattern |Regular expression that allows NetBeans IDE to find compiler in registry 
+|pattern |Regular expression that allows NetBeans IDE to find compiler in registry |
 
-|suffix |Folder with executable files 
+|suffix |Folder with executable files |
 
-|path_patern |Regular expression that allows NetBeans IDE to find compiler by scanning paths. Note that the XML tag must be spelled "path_patern" although this is a mispelling. 
+|path_patern |Regular expression that allows NetBeans IDE to find compiler by scanning paths. Note that the XML tag must be spelled "path_patern" although this is a mispelling. |
 
 |command_folders |Container for command_folder tags. 
-One or more commander_folder tags are contained in one command_folders tag. 
+One or more commander_folder tags are contained in one command_folders tag. |
 
 |command_folder |Describes the directory where UNIX-like commands are located.
-Only needed for MinGW compiler on Windows. The command_folder tag can contain the following tags: 
+Only needed for MinGW compiler on Windows. The command_folder tag can contain the following tags: |
 
-|regestry |Windows registry key of commands. Note that the XML tag must be spelled "regestry" although this is a mispelling. 
+|regestry |Windows registry key of commands. Note that the XML tag must be spelled "regestry" although this is a mispelling. |
 
-|pattern |Regular expression that allows NetBeans IDE to find the commands folder in the registry 
+|pattern |Regular expression that allows NetBeans IDE to find the commands folder in the registry |
 
-|suffix |Folder with executable files 
+|suffix |Folder with executable files |
 
-|path_patern |Regular expression that allows NetBeans IDE to find commands. Note that the XML tag must be spelled "path_patern" although this is a mispelling. 
+|path_patern |Regular expression that allows NetBeans IDE to find commands. Note that the XML tag must be spelled "path_patern" although this is a mispelling. |
 
-|scanner |Name of error parser service, see <<errorhandler,Creating a Custom Compiler Error Handler>> 
+|scanner |Name of error parser service, see <<errorhandler,Creating a Custom Compiler Error Handler>> |
 
 |id |Name of error parser service 
 |===
@@ -461,7 +461,7 @@ This table lists the tags used to describe the compilers and specify compiler fl
 |===
 |Tags |Description |Example for GNU compiler 
 
-|c,cpp |Set of compiler flags are located in following sub nodes 
+|c,cpp |Set of compiler flags are located in following sub nodes |
 
 |recognizer |Regular expression that allows the IDE to find compiler |For GNU under cygwin on Windows
 .*[\\/].*cygwin.*[\\/]bin[\\/]?$ 
@@ -480,11 +480,11 @@ This table lists the tags used to describe the compilers and specify compiler fl
 
 |user_macro |Flag to add user macro |-D 
 
-|development_mode |Groups of flags for different development modes 
+|development_mode |Groups of flags for different development modes |
 
-|warning_level |Groups of flags for different warning level 
+|warning_level |Groups of flags for different warning level |
 
-|architecture |Groups of flags for different architecture 
+|architecture |Groups of flags for different architecture |
 
 |strip |Flag for stripping debug information |-s 
 


### PR DESCRIPTION
Some of the tables, starting with "Tool collection definition tags" were defined as 3 columns while several of the lines had only 2 columns of data, leading to scrambled tables.
All I did was add a 3rd vertical bar on lines that didn't have them.  I have not evaluated the result for content, although at a glance it seems much more readable.