### PR TITLE
Add 12.0 LTS EOL information and fix up archived releases.

### DIFF
--- a/netbeans.apache.org/src/content/download/archive/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/archive/index.asciidoc
@@ -29,43 +29,55 @@
 Older Apache NetBeans releases and pre-Apache NetBeans releases can still be
 downloaded, but are no longer supported.
 
-== Apache NetBeans 12 feature update 3 (NB 12.3)
+== Apache NetBeans 12.4
+
+Apache NetBeans 12.4 was released on May 19, 2021.
+
+link:/download/nb124/index.html[Features, role="button"] link:/download/nb124/nb124.html[Download, role="button success"]
+
+== Apache NetBeans 12.3
 
 Apache NetBeans 12.3 was released on March 3, 2021.
 
 link:/download/nb123/index.html[Features, role="button"] link:/download/nb123/nb123.html[Download, role="button success"]
 
-== Apache NetBeans 12 feature update 2 (NB 12.2)
+== Apache NetBeans 12.2
 
 Apache NetBeans 12.2 was released on December 5, 2020.
 
 link:/download/nb122/index.html[Features, role="button"] link:/download/nb122/nb122.html[Download, role="button success"]
 
-== Apache NetBeans 12 feature update 1 (NB 12.1)
+== Apache NetBeans 12.1
 
 Apache NetBeans 12.1 was released on September 5, 2020.
 
 link:/download/nb121/index.html[Features, role="button"] link:/download/nb121/nb121.html[Download, role="button success"]
 
-== Apache NetBeans 11 feature update 3 (NB 11.3)
+== Apache NetBeans 12.0
+
+Apache NetBeans 12.0 LTS was released on June 4, 2020.
+
+link:/download/nb120/index.html[Features, role="button"] link:/download/nb120/nb120.html[Download, role="button success"]
+
+== Apache NetBeans 11.3
 
 Apache NetBeans 11.3 was released on February 24, 2020.
 
 link:/download/nb113/index.html[Features, role="button"] link:/download/nb113/nb113.html[Download, role="button success"]
 
-== Apache NetBeans 11 feature update 2 (NB 11.2)
+== Apache NetBeans 11.2
 
 Apache NetBeans 11.2 was released on October 25, 2019.
 
 link:/download/nb112/index.html[Features, role="button"] link:/download/nb112/nb112.html[Download, role="button success"]
 
-== Apache NetBeans 11 feature update 1 (NB 11.1)
+== Apache NetBeans 11.1
 
 Apache NetBeans 11.1 was released on July 22, 2019.
 
 link:/download/nb111/index.html[Features, role="button"] link:/download/nb111/nb111.html[Download, role="button success"]
 
-== Apache NetBeans 11 LTS (NB 11.0)
+== Apache NetBeans 11.0
 
 Apache NetBeans 11 LTS version of the IDE, released on April 4, 2019.
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -37,15 +37,20 @@ for important requirements for download pages for Apache projects.
 
 Apache NetBeans is released four times a year. For details, see link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[full release schedule].
 
-== Apache NetBeans 12 feature update 5 (NB 12.5)
+== Apache NetBeans 12.5
 
 Latest version of the IDE, released on September 13, 2021.
 
 link:/download/nb125/index.html[Features, role="button"] link:/download/nb125/nb125.html[Download, role="button success"]
 
-== Apache NetBeans 12 LTS (NB 12.0)
+== Apache NetBeans 12.0 LTS
 
-Latest LTS version of the IDE, released on June 4, 2020.
+Apache NetBeans 12.0 was released on June 4, 2020.
+
+TIP: Apache NetBeans 12.0 does not support Java 15 or above. The Apache NetBeans
+PMC has decided to no longer provide an LTS version of the IDE. Apache NetBeans
+12.0 will be EOL'd when NetBeans 12.6 is released. We recommend using the latest
+release.
 
 link:/download/nb120/index.html[Features, role="button"] link:/download/nb120/nb120.html[Download, role="button success"]
 

--- a/netbeans.apache.org/src/content/download/nb120/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb120/index.asciidoc
@@ -33,8 +33,6 @@
 
 Welcome to Apache NetBeans 12.0!
 
-TIP: The LTS release of the Apache NetBeans 12 cycle is Apache NetBeans 12.0, which consolidates the feature releases link:http://netbeans.apache.org/download/nb111/index.html[11.1], link:http://netbeans.apache.org/download/nb112/index.html[11.2], and link:http://netbeans.apache.org/download/nb113/index.html[11.3]. Feature releases have not been tested as heavily as the LTS release, which passes through the link:https://cwiki.apache.org/confluence/display/NETBEANS/Results+from+Apache+NetBeans+IDE+12.0+Community+Acceptance+survey[NetCAT Community Acceptance process]. For details, see the link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[Apache NetBeans quarterly release cycle].
-
 link:/download/nb120/nb120.html[Download, role="button success"]
 
 Below are the highlights of Apache NetBeans 12.0, for a full list, see the link:https://cwiki.apache.org/confluence/display/NETBEANS/Apache+NetBeans+12.0[Apache NetBeans 12.0 Wiki].


### PR DESCRIPTION
Added information on 12.0 being EOL'd in the near future, and that it doesn't support Java 15+. This was cause of a few issues on JIRA.

Also updated the archive page that was missing 12.4, and made the release titles simpler / consistent for our new post-LTS world! :smile: