### PR TITLE
Update information on supported JDK for 12.6 given issues raised ...

### DIFF
--- a/netbeans.apache.org/src/content/download/nb126/nb126.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb126/nb126.asciidoc
@@ -73,7 +73,9 @@ Apache NetBeans can also be installed as a self-contained link:https://snapcraft
 
 == Deployment Platforms
 
-Apache NetBeans 12.6 runs on JDK LTS releases 8 and 11, with experimental support for JDK 17, i.e., the current JDK release at the time of this NetBeans release.
+The Apache NetBeans 12.6 binary releases require JDK 11+, and officially support running on JDK 11 and JDK 17.
+
+IMPORTANT: Apache NetBeans 12.6 can be run on JDK 8, with some features disabled, if built from source using JDK 8.
 
 TIP: The current JDKs have an issue on macOS Big Sur, that causes freezes on dialogs. That could be fixed by applying the workaround described at link:https://issues.apache.org/jira/browse/NETBEANS-5037?focusedCommentId=17234878&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17234878[NETBEANS-5037] .
 


### PR DESCRIPTION
Update information on supported JDK given issues raised in NETBEANS-6285.  The page should have said 12.6 supports JDK 17 anyway, but we're jumping ahead slightly in marking JDK 8 as unsupported by the binaries.  Not ideal!  But does show we don't get enough user testing of RCs on JDK 8, so the decision to stop supporting it is right I guess.

https://issues.apache.org/jira/browse/NETBEANS-6285