### PR TITLE
Update some key JIRA links to point to GitHub issues.

### DIFF
--- a/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
+++ b/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
@@ -115,5 +115,5 @@ Receive GitHub notifications whenever someone adds a comment to an issue and whe
 - We also have a link:https://www.youtube.com/user/netbeansvideos[YouTube] channel.
 - Meet other users in the unofficial link:https://tinyurl.com/netbeans-slack-signup[NetBeans Slack channel]
 - There is also a NetBeans IRC channel (#netbeans) on link:https://libera.chat/[Libera].
-- Finally we use link:https://github.com/apache/netbeans[GitHub] as a source repository and link:https://issues.apache.org/jira/projects/NETBEANS/summary[JIRA] for issue reporting.
+- Finally, we use link:https://github.com/apache/netbeans[GitHub] as a source repository and for link:https://github.com/apache/netbeans/issues[issue tracking].
 

--- a/netbeans.apache.org/src/content/participate/report-issue.asciidoc
+++ b/netbeans.apache.org/src/content/participate/report-issue.asciidoc
@@ -20,16 +20,19 @@
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
-:keywords: Apache NetBeans JIRA issue report
+:keywords: Apache NetBeans issue report
 :description: Apache NetBeans Reporting Issues
 
-If you have found a bug in the application, please help Apache NetBeans by reporting this problem to our bug tracking system. Click View Data button, copy the exception and submit it together with detailed information about what you were trying to achieve before the problem occurred. NetBeans uses the link:https://issues.apache.org/jira/projects/NETBEANS/issues[JIRA] issue tracking system; you must have a login to file a new issue. Just click "Log In" in the upper-right of the page to create one. Once you are logged in, you will see a red "Create" button at the top of the page.
+If you have found a bug in the application, please help Apache NetBeans by reporting this problem
+to link:https://github.com/apache/netbeans/issues[our issue tracking on GitHub].
 
 Thank you for helping us make Apache NetBeans better!
 
 == Note
 
-Please provide the following information to reproduce your issues when you submit them.
+Please make sure the issue can be replicated with the latest Apache NetBeans release,
+and has not already been reported. Provide enough information for someone to be able
+to reproduce the problem. Sufficient information might include -
 
 - Example code (Attachments or Description)
 - Example project (Attachments)
@@ -37,9 +40,8 @@ Please provide the following information to reproduce your issues when you submi
 - Exact steps e.g. 1. Create an empty project, 2. Write the following code, 3. Something... (Description)
 - Actual results (Description)
 - Expected results (Description)
-- NetBeans version (Affects Version/s)
 - JDK version (Environment)
 - OS (Environment)
 
-link:https://issues.apache.org/jira/projects/NETBEANS/issues[Open JIRA, role="button success"]
+link:https://github.com/apache/netbeans/issues[Report issue, role="button success"]
 

--- a/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
+++ b/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
@@ -34,7 +34,7 @@ We follow link:https://www.apache.org/foundation/policies/conduct.html[the Apach
 
 We appreciate new contributors to adhere to the following guidelines, to make things easier for all of us:
 
-. Before starting to code, it is a good practice to open an issue (PTR) first in our link:https://issues.apache.org/jira/projects/NETBEANS/summary[JIRA] instance, and discuss the problem in the developer mailing list (see link:/community/mailing-lists.html[mailing lists]), giving the reason for submitting your pull request so that it is clear and more experienced members can suggest appropriate solutions/ideas.  
+. Before starting to code, you may want to discuss the problem in the developer mailing list (see link:/community/mailing-lists.html[mailing lists]), giving the reason for submitting your pull request so that it is clear and more experienced members can suggest appropriate solutions/ideas.
 . All commits must include the author's full name and email address. For *important modifications* you will need to submit an link:https://www.apache.org/licenses/icla.pdf[Individual Contributor License Agreement (ICLA)].
 . All new files must include the Apache Software Foundation license header. See any NetBeans source code in case of doubt.
 . All commits must contain a meaningful commit message.
@@ -111,7 +111,7 @@ Before you can start modifying or upgrading the NetBeans code in your repository
 . Change to the `master` branch with `git checkout master`.
 . Create a branch with `git checkout -b mybranch` (or, using two commands: `git branch mybranch` and `git checkout mybranch`).
 
-You are now ready to start modifying the NetBeans code. Use `git commit` when appropriate. Note that the commit message related to JIRA issues must start with `[NETBEANS-<issue number>]`.
+You are now ready to start modifying the NetBeans code. Use `git commit` when appropriate.
 
 - Use `git push -u origin mybranch` to create and push the `mybranch` branch in your GitHub fork. 
 - Use `git push origin mybranch` afterwards.
@@ -206,7 +206,7 @@ Donator can use pull request as show above. (squashed for having a better readab
 
 In order to accept a donation the Apache NetBeans PMC should do a vote to accept the intention of donation.
 
-PMC will have to setup a form to append the list at https://incubator.apache.org/ip-clearance/ and open a JIRA issue to track donation.
+PMC will have to setup a form to append the list at https://incubator.apache.org/ip-clearance/ and open an issue to track donation.
 
 Donator must ensure that the following step are ok (PMC member need to check): 
 


### PR DESCRIPTION
Change references and links from JIRA to GitHub issues on a few key pages, in particular the Report Issues page.

The Report Issues page is currently the landing page from the `Help / Report Issue` action (and elsewhere) in the IDE. It is redirected from https://netbeans.apache.org/nb/report-issue in .htaccess.  We could decide to redirect straight to https://github.com/apache/netbeans/issues/new/choose ?  I can update this PR with that.