### PR TITLE
Remove Upcoming events paragraph as the events already happened

### DIFF
--- a/netbeans.apache.org/src/content/community/events.asciidoc
+++ b/netbeans.apache.org/src/content/community/events.asciidoc
@@ -37,22 +37,10 @@ An "Apache NetBeans Day" is a class of event that happens regularly, with a clea
 
 For publicizing NetBeans events, the Apache News posts at https://blogs.apache.org/foundation/ can mention those events, best is to contact press@apache.org for that. Apache has an Event Listing (https://events.apache.org/), that we'd also like to make use of.
 
-=== Upcoming NetBeans related events in 2019/2020
-
-16-19th September 2019 Oracle CodeOne conference is Oracle's big developer conference for Java and other languages. You have to pay to attend but there are lots of excellent talks. It takes place at the Moscone Center in San Francisco, USA. link:https://www.oracle.com/code-one/[CodeOne Website] Here are the NetBeans related talks link:https://events.rainfocus.com/widget/oracle/oow19/catalogcodeone19?search=netbeans[NetBeans specific talks]
-
-27th September 2019 Apache NetBeans Day 2019 UK is a free one day conference in  London, UK. link:https://www.eventbrite.co.uk/e/apache-netbeans-day-2019-uk-tickets-56803479737[free tickets and more details]
-
-10th January 2020 Dawscon is a one day software development conference in Montreal, Canada. It will have several NetBeans enthusiastists speaking and at least one dedicated NetBeans talk. link:https://www.dawsoncollege.qc.ca/dawscon/
-
-This is a link to the next Apache Community major events:
-
-[caption="Apache Current Event", link=https://www.apache.org/events/current-event.html]
-image::https://www.apache.org/events/current-event-234x60.png[CurrentEvent,234,60]
-
 == Past NetBeans related events
-link:https://www.omnijava.com/2019/01/20/dawscon-2019/[Dawscon 2019 write-up]
-link:https://blog.idrsolutions.com/2018/04/key-takeaways-from-apache-netbeans-day-uk/[My Key Takeaways from Apache NetBeans Day UK 2018]
+- link:https://www.youtube.com/watch?v=ivPjmsSS8iU/[Dawscon 2021 - Everyday coding in NetBeans]
+- link:https://www.omnijava.com/2019/01/20/dawscon-2019/[Dawscon 2019 write-up]
+- link:https://blog.idrsolutions.com/2018/04/key-takeaways-from-apache-netbeans-day-uk/[My Key Takeaways from Apache NetBeans Day UK 2018]
 
 == Apache Software Foundation Resources For Events And Conferences
 


### PR DESCRIPTION
Removed Upcoming events paragraph as the events already happened. Also added link to a session from Dawscon 2021.