### PR TITLE
Remove note about building / running on JDK 8

### DIFF
--- a/netbeans.apache.org/src/content/download/nb13/nb13.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb13/nb13.asciidoc
@@ -71,8 +71,6 @@ Apache NetBeans can also be installed as a self-contained link:https://snapcraft
 
 The Apache NetBeans 13 binary releases require JDK 11+, and officially support running on JDK 11 and JDK 17.
 
-IMPORTANT: Apache NetBeans 13 can be run on JDK 8, with some features disabled, if built from source using JDK 8.
-
 TIP: The current JDKs have an issue on macOS Big Sur, that causes freezes on dialogs. That could be fixed by applying the workaround described at link:https://issues.apache.org/jira/browse/NETBEANS-5037?focusedCommentId=17234878&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17234878[NETBEANS-5037] .
 
 == Building from Source


### PR DESCRIPTION
Remove the note about building / running on JDK 8. This was intended purely for 12.6.