### PR TITLE
Add community installers section to download page

### DIFF
--- a/netbeans.apache.org/src/content/download/nb13/nb13.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb13/nb13.asciidoc
@@ -67,6 +67,18 @@ The PGP keys used to sign this release are available link:https://downloads.apac
 
 Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 
+== Community Installers
+
+IMPORTANT: Individual NetBeans committers may provide additional binary packages as a convenience.
+While built using the Apache NetBeans release, they are not releases of the Apache Software
+Foundation. They may include other contents (eg. JDK) under additional license terms.
+
+- link:https://www.codelerity.com/netbeans/[Codelerity / Gj IT packages] - Windows, macOS and
+Linux (.deb / .AppImage) built with
+link:https://github.com/apache/netbeans-tools/tree/master/nbpackage[NBPackage]. Most
+include a local JDK runtime for the IDE to run on, for a self-contained out-of-the-box
+experience (other JDK's may be used for projects).
+
 == Deployment Platforms
 
 The Apache NetBeans 13 binary releases require JDK 11+, and officially support running on JDK 11 and JDK 17.


### PR DESCRIPTION
Added a community installers section to download page, with important info on them not being official ASF binaries / possible additional terms, along with links to Codelerity / Gj IT installers.