### PR TITLE
Update to fix problem for ./configure: no such file or directory

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test.asciidoc
@@ -176,7 +176,7 @@ These instructions assume you downloaded the file CUnit-2.1-2-src.tar.bz2 into t
 $ cd c:/distr
 $ bunzip2.exe CUnit-2.1-2-src.tar.bz2
 $ tar xvf CUnit-2.1-2-src.tar
-$ cd ./CUnit-2.1-2
+$ cd /CUnit-2.1-2
 ----
 
 [start=4]
@@ -205,7 +205,9 @@ If your MinGW is not in /mingw, be sure to specify the appropriate Unix location
 
 [source,shell]
 ----
-
+$ libtoolize
+$ automake --add-missing 
+$ autoreconf
 $ ./configure --prefix=/mingw
 _(lots of output about checking and configuring)
 ..._


### PR DESCRIPTION
This update fixes the problem for the configure file since for the new CUnit release (2.1-3) the downloaded tearred package doesnt contain the configure file