### PR TITLE
Removed the hint at the download page that pre-Apache versions can be downloaded at Oracle...

### DIFF
--- a/netbeans.apache.org/src/content/download/archive/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/archive/index.asciidoc
@@ -26,8 +26,7 @@
 :description: Apache NetBeans archive releases
 :linkattrs:
 
-Older Apache NetBeans releases and pre-Apache NetBeans releases can still be
-downloaded, but are no longer supported.
+Older Apache NetBeans releases can still be downloaded, but are no longer supported.
 
 == Apache NetBeans 13
 
@@ -115,7 +114,7 @@ link:/download/nb90/[Features, role="button"] link:/download/nb90/nb90.html[Down
 
 == Pre-Apache NetBeans versions
 
-Oracle still distributes previous versions of NetBeans bundled with their JDK.
-
--  link:https://www.oracle.com/technetwork/java/javase/downloads/jdk-netbeans-jsp-3413139-esa.html[JDK 8u111 with NetBeans 8.2]
+While Oracle distributed previous versions of NetBeans bundled with their JDK for
+a while this is no longer the case. There is no official source anymore to download
+previous versions.
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -45,8 +45,7 @@ link:/download/nb14/nb14.html[Download, role="button success"]
 
 == Older releases
 
-Older Apache NetBeans releases and pre-Apache NetBeans releases can still be
-downloaded, but are no longer supported.
+Older Apache NetBeans releases can still be downloaded, but are no longer supported.
 
 link:/download/archive/index.html[Find out more, role="button"]
 


### PR DESCRIPTION
... since this is no longer the case