### PR TITLE
apidoc referenced specs (web archive)

### DIFF
--- a/netbeans.apache.org/src/content/projects/autoupdate/nbm/nbm_package.asciidoc
+++ b/netbeans.apache.org/src/content/projects/autoupdate/nbm/nbm_package.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= NetBeans: AutoUpdate NBM package technology
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry autoupdate nbm/nbm_package
+:description: former site entry  autoupdate nbm/nbm_package
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20080705031908/http://autoupdate.netbeans.org/nbm/nbm_package.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/buildsys/build-sys-ui-spec.asciidoc
+++ b/netbeans.apache.org/src/content/projects/buildsys/build-sys-ui-spec.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Build System UI Spec 
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry projects.netbeans.org/buildsys/build-sys-ui-spec.html
+:description: former site entry  projects.netbeans.org/buildsys/build-sys-ui-spec.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20041205051733/http://projects.netbeans.org/buildsys/build-sys-ui-spec.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/buildsys/design.asciidoc
+++ b/netbeans.apache.org/src/content/projects/buildsys/design.asciidoc
@@ -1,0 +1,36 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Build System Design
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry projects.netbeans.org/buildsys/design.html
+:description: former site entry projects.netbeans.org/buildsys/design.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20070929073058/http://projects.netbeans.org/buildsys/design.html[Web archive]
+
+//// anchor to no forget
+[[freeform]]
+link:https://web.archive.org/web/20070929073058/http://projects.netbeans.org/buildsys/design.html#freeform[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/buildsys/j2se-project-ui-spec.asciidoc
+++ b/netbeans.apache.org/src/content/projects/buildsys/j2se-project-ui-spec.asciidoc
@@ -1,0 +1,41 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= J2SE Project Type UI Spec 
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry projects.netbeans.org/buildsys/j2se-project-ui-spec.html
+:description: former site entry projects.netbeans.org/buildsys/j2se-project-ui-spec.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20050307011542/http://projects.netbeans.org/buildsys/j2se-project-ui-spec.html[Web archive]
+
+
+//// anchor to no forget
+[[Build_Compiling_Sources]]
+link:https://web.archive.org/web/20050307011542/http://projects.netbeans.org/buildsys/j2se-project-ui-spec.html#Build_Compiling_Sources[Web archive]
+
+[[Dialog_Java_Platform_Manager]]
+link:https://web.archive.org/web/20050307011542/http://projects.netbeans.org/buildsys/j2se-project-ui-spec.html#Dialog_Java_Platform_Manager[Web archive]
+
+[[Dialog_Library_Manager]]
+link:https://web.archive.org/web/20050307011542/http://projects.netbeans.org/buildsys/j2se-project-ui-spec.html#Dialog_Library_Manager[Web archive]

--- a/netbeans.apache.org/src/content/projects/lexer/index.asciidoc
+++ b/netbeans.apache.org/src/content/projects/lexer/index.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Lexer Module
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry lexer.netbeans.org/
+:description: former site entry  lexer.netbeans.org/
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20090309235451/http://lexer.netbeans.org/[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/lexer/token-id-naming.asciidoc
+++ b/netbeans.apache.org/src/content/projects/lexer/token-id-naming.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= TokenId Naming
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry lexer.netbeans.org/doc/token-id-naming.html
+:description: former site entry  lexer.netbeans.org/doc/token-id-naming.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20090321124943/http://lexer.netbeans.org/doc/token-id-naming.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/platform/articles/installation.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/articles/installation.asciidoc
@@ -1,0 +1,36 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Installation Structure
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry platform.netbeans.org/articles/installation.html
+:description: former site entry platform.netbeans.org/articles/installation.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20210118080511/https://platform.netbeans.org/articles/installation.html[Web archive]
+
+
+//// anchor to no forget
+[[launcher]]
+link:https://web.archive.org/web/20111223111616/http://openide.netbeans.org/proposals/actions/impl.html#launcher[Web archive]
+

--- a/netbeans.apache.org/src/content/projects/platform/core/windowsystem/changes.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/core/windowsystem/changes.asciidoc
@@ -1,0 +1,47 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= New Window System API Changes
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry core.netbeans.org/windowsystem/changes.html
+:description: former site entry  core.netbeans.org/windowsystem/changes.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20210306023217/https://core.netbeans.org/windowsystem/changes.html[Web archive]
+
+
+//// anchor to no forget
+
+[[2.3]]
+link:https://web.archive.org/web/20210306023217/https://core.netbeans.org/windowsystem/changes.html#2.3[Web archive]
+
+[[3.4.2]]
+link:https://web.archive.org/web/20210306023217/https://core.netbeans.org/windowsystem/changes.html#3.4.2[Web archive]
+
+[[3.4.6]]
+link:https://web.archive.org/web/20210306023217/https://core.netbeans.org/windowsystem/changes.html#3.4.6[Web archive]
+
+[[4]]
+link:https://web.archive.org/web/20210306023217/https://core.netbeans.org/windowsystem/changes.html#4[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/platform/core/windowsystem/index.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/core/windowsystem/index.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= NetBeans: Window System
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry core.netbeans.org/windowsystem/index.html
+:description: former site entry  core.netbeans.org/windowsystem/index.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20200921070755/http://core.netbeans.org/windowsystem/index.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/platform/openide/proposals/actions/design.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/openide/proposals/actions/design.asciidoc
@@ -1,0 +1,33 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Design document covering architecture of solutions in actions system
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry openide.netbeans.org/proposals/actions/design.html
+:description: former site entry openide.netbeans.org/proposals/actions/design.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+//// anchor to no forget
+[[callback]]
+link:https://web.archive.org/web/20210127144457/http://openide.netbeans.org/proposals/actions/design.html#callback[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/platform/openide/proposals/actions/impl.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/openide/proposals/actions/impl.asciidoc
@@ -1,0 +1,36 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Document describing implemented changes in action system
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry core.netbeans.org/windowsystem/index.html
+:description: former site entry  core.netbeans.org/windowsystem/index.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20111223111616/http://openide.netbeans.org/proposals/actions/impl.html[Web archive]
+
+//// anchor to no forget
+[[summaryAPI]]
+link:https://web.archive.org/web/20111223111616/http://openide.netbeans.org/proposals/actions/impl.html#summaryAPI[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/platform/openide/proposals/actions/index.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/openide/proposals/actions/index.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= The central place for rework of Actions API
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry openide.netbeans.org/proposals/actions/index.html
+:description: former site entry  openide.netbeans.org/proposals/actions/index.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20120306084442/http://openide.netbeans.org/proposals/actions/index.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/platform/openide/proposals/arch/cli.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/openide/proposals/arch/cli.asciidoc
@@ -1,0 +1,34 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Command Line Interface and Locking User Directory
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry openide.netbeans.org/proposals/arch/cli.html
+:description: former site entry  openide.netbeans.org/proposals/arch/cli.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20210306060542/https://openide.netbeans.org/proposals/arch/cli.html[Web archive]
+
+//// anchor to no forget
+[[cli]]
+link:https://web.archive.org/web/20210306060542/https://openide.netbeans.org/proposals/arch/cli.html#cli[Web archive]

--- a/netbeans.apache.org/src/content/projects/platform/openide/tutorial/review/opinions_37386.asciidoc
+++ b/netbeans.apache.org/src/content/projects/platform/openide/tutorial/review/opinions_37386.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Web Deployment Descriptor API - Architecture Review Opinion
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry openide.netbeans.org/tutorial/reviews/opinions_37386.html
+:description: former site entry openide.netbeans.org/tutorial/reviews/opinions_37386.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20100716153353/http://openide.netbeans.org/tutorial/reviews/opinions_37386.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/schema2beans/index.asciidoc
+++ b/netbeans.apache.org/src/content/projects/schema2beans/index.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Schema2beans
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry schema2beans.netbeans.org
+:description: former site entry schema2beans.netbeans.org
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20071006043330/http://schema2beans.netbeans.org/[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/translatedfiles/index.asciidoc
+++ b/netbeans.apache.org/src/content/projects/translatedfiles/index.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= NetBeans: AutoUpdate NBM package technology
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry autoupdate nbm/nbm_package
+:description: former site entry  autoupdate nbm/nbm_package
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20080705031908/http://autoupdate.netbeans.org/nbm/nbm_package.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/ui/code_folding/cf_uispec.asciidoc
+++ b/netbeans.apache.org/src/content/projects/ui/code_folding/cf_uispec.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+=  Code Folding - User Interface Specification
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry ui.netbeans.org/docs/ui/code_folding/cf_uispec.html
+:description: former site entry ui.netbeans.org/docs/ui/code_folding/cf_uispec.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20150502124724/http://ui.netbeans.org/docs/ui/code_folding/cf_uispec.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/ui/themes/themes.asciidoc
+++ b/netbeans.apache.org/src/content/projects/ui/themes/themes.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= NetBeans and Themes
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry ui.netbeans.org/docs/ui/themes/themes.html
+:description: former site entry ui.netbeans.org/docs/ui/themes/themes.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20200805132329/https://ui.netbeans.org/docs/ui/themes/themes.html[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/ui/versioningspecification/index.asciidoc
+++ b/netbeans.apache.org/src/content/projects/ui/versioningspecification/index.asciidoc
@@ -1,0 +1,32 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= Support of the Control versioning systems in NetBeans UI Specification 
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry ui.netbeans.org/docs/ui/VersioningSpecification/
+:description: former site entry ui.netbeans.org/docs/ui/VersioningSpecification/
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20120701024355/http://ui.netbeans.org/docs/ui/VersioningSpecification/[Web archive]
+
+

--- a/netbeans.apache.org/src/content/projects/ui/ws/ws_spec.asciidoc
+++ b/netbeans.apache.org/src/content/projects/ui/ws/ws_spec.asciidoc
@@ -1,0 +1,40 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+= User Interface Specification: Window System, Final Draft
+:jbake-type: page
+:jbake-tags: community
+:jbake-status: published
+:keywords: former site entry ui.netbeans.org/docs/ui/ws/ws_spec.html
+:description: former site entry ui.netbeans.org/docs/ui/ws/ws_spec.html
+:toc: left
+:toclevels: 4
+:toc-title: 
+
+
+link:https://web.archive.org/web/20210118064428/https://ui.netbeans.org/docs/ui/ws/ws_spec.html[Web archive]
+
+//// anchor to no forget
+[[3.7]]
+link:https://web.archive.org/web/20210118064428/https://ui.netbeans.org/docs/ui/ws/ws_spec.html#3.7[Web archive]
+
+//// anchor to no forget
+[[3.9]]
+link:https://web.archive.org/web/20210118064428/https://ui.netbeans.org/docs/ui/ws/ws_spec.html#3.9[Web archive]
+
+


### PR DESCRIPTION
Hi this is a bit like #607

Page contains only a redirection to web.archive of the former site. So we can at least get the info instead of having a 404 from apidoc.

There is not a lot of pages. I try to reorganize in only one projects folder hope it make sense.
