### PR TITLE
updated issue tracker links.

### DIFF
--- a/netbeans.apache.org/src/content/templates/platform_tutorial.gsp
+++ b/netbeans.apache.org/src/content/templates/platform_tutorial.gsp
@@ -46,8 +46,7 @@
                   <tbody><tr>
                   <td class="icon"><i class="fa icon-note" title="Note"></i></td>
                   <td class="content">This tutorial needs a review. 
-                     You can <a href="https://issues.apache.org/jira/projects/NETBEANS/issues">open a JIRA issue</a>, 
-                     or <a href="https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
+                     You can <a href="https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
                      following these <a href="/kb/docs/contributing.html">contribution guidelines.</a></td>
                   </tr></tbody>
                 </table>

--- a/netbeans.apache.org/src/content/templates/tools.gsp
+++ b/netbeans.apache.org/src/content/templates/tools.gsp
@@ -25,7 +25,7 @@
         <li><a title="Github" href="https://github.com/apache/netbeans"><i class="fa fa-md fa-github"></i></a></li>
         <li><a title="YouTube" href="https://www.youtube.com/user/netbeansvideos"><i class="fa fa-md fa-youtube"></i></a></li>
         <li><a title="Slack" href="https://tinyurl.com/netbeans-slack-signup/"><i class="fa fa-md fa-slack"></i></a></li>
-        <li><a title="JIRA" href="https://issues.apache.org/jira/projects/NETBEANS/summary"><i class="fa fa-mf fa-bug"></i></a></li>
+        <li><a title="Issues" href="https://github.com/apache/netbeans/issues"><i class="fa fa-mf fa-bug"></i></a></li>
     </ul>
     <ul class="menu align-center">
         <%

--- a/netbeans.apache.org/src/content/templates/tutorial.gsp
+++ b/netbeans.apache.org/src/content/templates/tutorial.gsp
@@ -46,8 +46,7 @@
                   <tbody><tr>
                   <td class="icon"><i class="fa icon-note" title="Note"></i></td>
                   <td class="content">This tutorial needs a review. 
-                     You can <a href="https://issues.apache.org/jira/projects/NETBEANS/issues">open a JIRA issue</a>, 
-                     or <a href="https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
+                     You can <a href="https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
                      following these <a href="/kb/docs/contributing.html">contribution guidelines.</a></td>
                   </tr></tbody>
                 </table>


### PR DESCRIPTION
 - Removed the (outdated) links to the issue tracker on the "requires review" templates since I don't think filing issues is useful at this state of the page. The "edit page" links should be preferred.
 - updated link in footer

I haven't updated this page:
https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src/content/nb/issues.html
since it looks like something which used to be embedded in netbeans and is no longer used (probably this: https://github.com/apache/netbeans/pull/3410) and can be potentially removed in future.