### PR TITLE
Misspelling in the Developing General Java Applications' page. 

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro.asciidoc
@@ -274,7 +274,7 @@ In the *Create/Update Tests* dialog box, click *OK* to run the command with the 
 
 In the *Projects* window you will see that the IDE has created the `org.me.mylib` package, the `LibClassTest.java` file in the *MyLib > Test Packages*  folder and, created the *MyLib > Test Libraries* folder. Finally the file `LibClassTest.java` is opened in the editor.
 
-In the *Projects* window, right-click the *Test Libraries* node and select *Properties*.  In the *Project Properties - MyLib* window, select *Categories: Libraries*. In the right-hand pane select the *Compile Tests* tab and click the ` *+* ` button. From the pop-up list select *Add Library*, from the *Global Libraries* folder select `JUnit 4.x` and click *Add Libray* repeat, this time selecting the `Hamcrest 1.x` library.
+In the *Projects* window, right-click the *Test Libraries* node and select *Properties*.  In the *Project Properties - MyLib* window, select *Categories: Libraries*. In the right-hand pane select the *Compile Tests* tab and click the ` *+* ` button. From the pop-up list select *Add Library*, from the *Global Libraries* folder select `JUnit 4.x` and click *Add Library* repeat, this time selecting the `Hamcrest 1.x` library.
 
 In `LibClassTest.java`, delete the body of the `public void testAcrostic()` method and, in place of the deleted lines, type or paste in the following:
 


### PR DESCRIPTION
In the page 'Developing General Java Applications', line 277 that starts with 'In the Projects window...', has the sentence:
'...JUnit 4.x and click **Add Libray** repeat...'. 
The word **Library** is misspelled as **Libray**. This commit only changes this word.