### PR TITLE
Update NB16 page Linux info and prepare NB15 for archive

### DIFF
--- a/netbeans.apache.org/src/content/download/archive/index.adoc
+++ b/netbeans.apache.org/src/content/download/archive/index.adoc
@@ -30,7 +30,7 @@ Older Apache NetBeans releases can still be downloaded, but are no longer suppor
 
 == Apache NetBeans 15
 
-Apache NetBeans 15 was released on November 30, 2022.
+Apache NetBeans 15 was released on August 31, 2022.
 
 link:https://github.com/apache/netbeans/releases/tag/15[Features, role="button"] xref:../nb15/index.adoc[Download, role="button success"]
 

--- a/netbeans.apache.org/src/content/download/nb15/index.adoc
+++ b/netbeans.apache.org/src/content/download/nb15/index.adoc
@@ -35,8 +35,8 @@ for important requirements for download pages for Apache projects.
 
 // check version above
 :netbeans-version: 15
-:url-download-keychecksum: https://downloads.apache.org/netbeans/
-:url-download: https://www.apache.org/dyn/closer.cgi/netbeans/
+:url-download-keychecksum: https://archive.apache.org/dist/netbeans/
+:url-download: https://archive.apache.org/dist/netbeans/
 
 //// 
 url-download depends of release status archived or not

--- a/netbeans.apache.org/src/content/download/nb16/index.adoc
+++ b/netbeans.apache.org/src/content/download/nb16/index.adoc
@@ -35,8 +35,12 @@ for important requirements for download pages for Apache projects.
 
 // check version above
 :netbeans-version: 16
-:url-download-keychecksum: https://downloads.apache.org/netbeans/
+
+// base URLs - when archiving, delete the next 2 lines and uncomment the following 2
 :url-download: https://www.apache.org/dyn/closer.cgi/netbeans/
+:url-download-keychecksum: https://downloads.apache.org/netbeans/
+// :url-download: https://archive.apache.org/dist/netbeans/
+// :url-download-keychecksum: https://archive.apache.org/dist/netbeans/
 
 //// 
 url-download depends of release status archived or not
@@ -48,7 +52,7 @@ https://archive.apache.org/dist/netbeans/  (//archived)
 https://downloads.apache.org/netbeans/ (//current)
 ////
 
-Apache NetBeans {netbeans-version} was released on November 30, 2022. link:https://github.com/apache/netbeans/releases/tag/{netbeans-version}[Go here on GitHub] for a list of fixed issues for Apache NetBeans {netbeans-version}.
+Apache NetBeans {netbeans-version} was released on November 30, 2022. See link:https://github.com/apache/netbeans/releases/tag/{netbeans-version}[Release Notes on GitHub] for all changes in Apache NetBeans {netbeans-version}.
 
 ////
 NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
@@ -67,6 +71,10 @@ link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-ve
 link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-windows-x64.exe.asc[PGP ASC])
 * link:{url-download}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-macosx.dmg[Apache-NetBeans-{netbeans-version}-bin-macosx.dmg] (link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-macosx.dmg.sha512[SHA-512],
 link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-macosx.dmg.asc[PGP ASC])
+* link:{url-download}netbeans-installers/{netbeans-version}/apache-netbeans_{netbeans-version}-1_all.deb[apache-netbeans_{netbeans-version}-1_all.deb] (link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans_{netbeans-version}-1_all.deb.sha512[SHA-512],
+link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans_{netbeans-version}-1_all.deb.asc[PGP ASC])
+* link:{url-download}netbeans-installers/{netbeans-version}/apache-netbeans-{netbeans-version}-0.noarch.rpm[apache-netbeans-{netbeans-version}-0.noarch.rpm] (link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans-{netbeans-version}-0.noarch.rpm.sha512[SHA-512],
+link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans-{netbeans-version}-0.noarch.rpm.asc[PGP ASC])
 
 - Source: link:{url-download}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip[netbeans-{netbeans-version}-source.zip] (link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip.sha512[SHA-512],
 link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip.asc[PGP ASC])
@@ -80,8 +88,6 @@ The PGP keys used to sign this release are available link:https://downloads.apac
 
 Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
 
-* Tip: Linux users: use the binary zip, link:https://snapcraft.io/netbeans[Snap], or our link:https://codelerity.com/netbeans[community installers] (there is a .deb without JDK too). This has been discussed on dev@ a little while back. Linux installer is a little broken and no-one has fixed it yet.
-
 == Community Installers
 
 IMPORTANT: Individual NetBeans committers may provide additional binary packages as a convenience.
@@ -89,8 +95,8 @@ While built using the Apache NetBeans release, they are not releases of the Apac
 Foundation. They may include other contents (eg. JDK) under additional license terms.
 
 - link:https://www.codelerity.com/netbeans/[Codelerity / Gj IT packages] - Windows, macOS and
-Linux (.deb / .AppImage) built with
-link:https://github.com/apache/netbeans-tools/tree/master/nbpackage[NBPackage]. Most
+Linux (.deb / .rpm / .AppImage) built with
+link:https://github.com/apache/netbeans-nbpackage/[NBPackage]. Most
 include a local JDK runtime for the IDE to run on, for a self-contained out-of-the-box
 experience (other JDK's may be used for projects).
 
@@ -98,13 +104,13 @@ experience (other JDK's may be used for projects).
 
 The Apache NetBeans {netbeans-version} binary releases require JDK 11+, and officially support running on JDK 11 and JDK 17.
 
-TIP: The current JDKs have an issue on macOS Big Sur, that causes freezes on dialogs. That could be fixed by applying the workaround described at link:https://issues.apache.org/jira/browse/NETBEANS-5037?focusedCommentId=17234878&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17234878[NETBEANS-5037] .
+TIP: Gradle projects in Apache NetBeans 16 are not supported when running the IDE on JDK 19.
 
 == Building from Source
 
 To build Apache NetBeans {netbeans-version} from source you need:
 
-. A distribution of OpenJDK 8 or 11.
+. A distribution of OpenJDK 11.
 . Apache Ant 1.10 or greater (link:https://ant.apache.org[https://ant.apache.org]).
 
 Once you have everything installed then:


### PR DESCRIPTION
I've added in the Linux DEB and RPM packages to the NB16 page, and updated a few other bits of text.  Replaced the macOS tip, which is fixed in the JDK as far as I know, with temporary info on Gradle and JDK 19.

Updated the NB15 page to use the archive links.  Also added an update and commented out lines on the NB16 page for when it is time to archive that.  Had to remind myself how Eric had set up the variables (which makes it much easier when you remember! :smile: )