### PR TITLE
small download page cleanup.

### DIFF
--- a/netbeans.apache.org/src/content/download/nb16/index.adoc
+++ b/netbeans.apache.org/src/content/download/nb16/index.adoc
@@ -52,8 +52,7 @@ https://archive.apache.org/dist/netbeans/  (//archived)
 https://downloads.apache.org/netbeans/ (//current)
 ////
 
-Apache NetBeans {netbeans-version} was released on November 30, 2022. See link:https://github.com/apache/netbeans/releases/tag/{netbeans-version}[Release Notes on GitHub] for all changes in Apache NetBeans {netbeans-version}.
-
+Apache NetBeans {netbeans-version} was released on November 30, 2022.
 ////
 NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
 NOTE: It's mandatory to link against https://www.apache.org for the sums & keys. https is recommended.
@@ -61,11 +60,12 @@ NOTE: It's NOT recommended to link to github.
 ////
 Apache NetBeans {netbeans-version} is available for download from your closest Apache mirror.
 
-- Binaries: 
-link:{url-download}netbeans/{netbeans-version}/netbeans-{netbeans-version}-bin.zip[netbeans-{netbeans-version}-bin.zip] (link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-bin.zip.sha512[SHA-512],
+*Binaries (Platform Independent):*
+
+* link:{url-download}netbeans/{netbeans-version}/netbeans-{netbeans-version}-bin.zip[netbeans-{netbeans-version}-bin.zip] (link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-bin.zip.sha512[SHA-512],
 link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-bin.zip.asc[PGP ASC])
 
-- Installers:
+*Installers and Packages:*
 
 * link:{url-download}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-windows-x64.exe[Apache-NetBeans-{netbeans-version}-bin-windows-x64.exe] (link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-windows-x64.exe.sha512[SHA-512],
 link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/Apache-NetBeans-{netbeans-version}-bin-windows-x64.exe.asc[PGP ASC])
@@ -75,36 +75,47 @@ link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/Apache-Net
 link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans_{netbeans-version}-1_all.deb.asc[PGP ASC])
 * link:{url-download}netbeans-installers/{netbeans-version}/apache-netbeans-{netbeans-version}-0.noarch.rpm[apache-netbeans-{netbeans-version}-0.noarch.rpm] (link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans-{netbeans-version}-0.noarch.rpm.sha512[SHA-512],
 link:{url-download-keychecksum}netbeans-installers/{netbeans-version}/apache-netbeans-{netbeans-version}-0.noarch.rpm.asc[PGP ASC])
+* link:https://snapcraft.io/netbeans[Linux snap package]
 
-- Source: link:{url-download}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip[netbeans-{netbeans-version}-source.zip] (link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip.sha512[SHA-512],
+*Source:*
+
+* link:{url-download}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip[netbeans-{netbeans-version}-source.zip] (link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip.sha512[SHA-512],
 link:{url-download-keychecksum}netbeans/{netbeans-version}/netbeans-{netbeans-version}-source.zip.asc[PGP ASC])
 
-////
-NOTE: Using https below is highly recommended.
-////
 Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity]
 of the downloaded files using the PGP signatures (.asc file) or a hash (.sha512 files).
 The PGP keys used to sign this release are available link:https://downloads.apache.org/netbeans/KEYS[here].
 
-Apache NetBeans can also be installed as a self-contained link:https://snapcraft.io/netbeans[snap package] on Linux.
+*Release Notes:*
+
+* link:https://github.com/apache/netbeans/releases/tag/{netbeans-version}[Github Link]
 
 == Community Installers
-
-IMPORTANT: Individual NetBeans committers may provide additional binary packages as a convenience.
-While built using the Apache NetBeans release, they are not releases of the Apache Software
-Foundation. They may include other contents (eg. JDK) under additional license terms.
 
 - link:https://www.codelerity.com/netbeans/[Codelerity / Gj IT packages] - Windows, macOS and
 Linux (.deb / .rpm / .AppImage) built with
 link:https://github.com/apache/netbeans-nbpackage/[NBPackage]. Most
 include a local JDK runtime for the IDE to run on, for a self-contained out-of-the-box
-experience (other JDK's may be used for projects).
+experience.
+
+
+IMPORTANT: Individual NetBeans committers may provide additional binary packages as a convenience.
+While built using the Apache NetBeans release, they are not releases of the Apache Software
+Foundation. They may include other contents (eg. JDK) under additional license terms.
 
 == Deployment Platforms
 
 The Apache NetBeans {netbeans-version} binary releases require JDK 11+, and officially support running on JDK 11 and JDK 17.
 
-TIP: Gradle projects in Apache NetBeans 16 are not supported when running the IDE on JDK 19.
+TIP: The Runtime JDK NetBeans uses does not influence the JDK range projects can use.
+
+== Known Issues
+
+* Gradle projects in Apache NetBeans 16 are currently not supported when running the IDE on JDK 19.
+
+* link:https://github.com/apache/netbeans/issues[All Issues on GitHub]
+
+* link:https://netbeans.apache.org/participate/report-issue.html[How to Report an Issue]
 
 == Building from Source
 
@@ -121,6 +132,8 @@ in a directory of your liking.
 [start=2]
 . `cd` to that directory, and then run `ant` to build the Apache NetBeans IDE.
 Once built you can run the IDE by typing `./nbbuild/netbeans/bin/netbeans`
+
+For more details refer to the README.
 
 == Community Approval
 


### PR DESCRIPTION
moved a few items around for improved readability and consistency.

 * some inline sidenote has been moved down to `Deployment Platforms` as additional `tip`
 * snap moved to community section
 * mentioned that the zip is platform independent. This required to change the bullet list slightly otherwise it would have looked ugly.
 * tips/warning annotations are now consistently below the main text block. Since one was below and the other above.

[link to github preview](https://github.com/apache/netbeans-website/blob/afc6f1984febde6c5d860deddd3b0aeb97e0786f/netbeans.apache.org/src/content/download/nb16/index.adoc)