### PR TITLE
Update nbm-filetemplates.adoc

### DIFF
--- a/netbeans.apache.org/src/content/tutorials/nbm-filetemplates.adoc
+++ b/netbeans.apache.org/src/content/tutorials/nbm-filetemplates.adoc
@@ -225,7 +225,7 @@ Once you have defined the file template, the description file, and the icon, you
 
 
 [start=1]
-1. Right-click the module in the Projects window, choose Properties, and use the Libraries tab to add dependencies on Datasystems API and Utilities API.
+1. Right-click the module in the Projects window, choose Properties, and use the Libraries tab to add dependencies on File Templates and Base Utilities API.
 
 [start=2]
 1. 


### PR DESCRIPTION
Updated File Templates Tutorial from referencing NetBeans 7.4 API locations.

- Changed the reference from "Datasystems API" to "File Templates" for the `TemplateRegistration` class
- Changed the reference from "Utilities API" to "Base Utilities API" for the `NbBundle` and `NbBundle.Messages` classes.

-SC