### PR TITLE
nb17 dl page: removed resolved known issue.

### DIFF
--- a/netbeans.apache.org/src/content/download/nb17/index.adoc
+++ b/netbeans.apache.org/src/content/download/nb17/index.adoc
@@ -111,8 +111,6 @@ TIP: The Runtime JDK NetBeans uses does not influence the JDK range projects can
 
 == Known Issues
 
-* Gradle projects in Apache NetBeans 17 are currently not supported when running the IDE on JDK 19.
-
 * link:https://github.com/apache/netbeans/issues[All Issues on GitHub]
 
 * link:https://netbeans.apache.org/participate/report-issue.html[How to Report an Issue]


### PR DESCRIPTION
chatted with @lkishalmi about this and this warning isn't needed anymore since the upgrade to gradle 8.0-rc1 resolved the JDK compatibility issue.