### PR TITLE
Update nbm-filetemplates.adoc

### DIFF
--- a/netbeans.apache.org/src/content/tutorials/nbm-filetemplates.adoc
+++ b/netbeans.apache.org/src/content/tutorials/nbm-filetemplates.adoc
@@ -29,6 +29,7 @@
 :experimental:
 :description: NetBeans File Template Module Tutorial - Apache NetBeans
 :keywords: Apache NetBeans Platform, Platform Tutorials, NetBeans File Template Module Tutorial
+:reviewed: 2023-02-25
 
 This tutorial demonstrates how to create a NetBeans module providing file templates. Once your users have installed the module in the IDE, the file templates are available to them in the New File wizard. Sharing file templates is easy once you have a module that contains them—the IDE lets you create a binary that you can make available to others, who can then install it through the Plugin Manager.
 
@@ -105,8 +106,7 @@ The template file defines the content that the template will generate for the us
 1. Right-click the  ``AdditionalFileTemplates``  node and choose New > Other. In the New File wizard, under Categories, choose Other and under File Types, choose HTML. Click Next.
 
 [start=2]
-1. 
-Type  ``HTML``  in File Name. Click Browse and browse to  ``src/org/myorg/additionalfiletemplates`` . Click Select Folder. Click Finish. A new HTML file, named  ``HTML.html`` , opens in the Source Editor, containing the standard HTML file's content shown below:
+1. Type  ``HTML``  in File Name. Click Browse and browse to  ``src/org/myorg/additionalfiletemplates`` . Click Select Folder. Click Finish. A new HTML file, named  ``HTML.html`` , opens in the Source Editor, containing the standard HTML file's content shown below:
 
 
 [source,html]
@@ -123,7 +123,6 @@ Type  ``HTML``  in File Name. Click Browse and browse to  ``src/org/myorg/additi
   </body>
 </html>
 ----
-
 
 [start=3]
 1. Change the HTML file according to your needs. You can add the following predefined variables, if needed:
@@ -228,9 +227,7 @@ Once you have defined the file template, the description file, and the icon, you
 1. Right-click the module in the Projects window, choose Properties, and use the Libraries tab to add dependencies on Datasystems API and Utilities API.
 
 [start=2]
-1. 
-Right-click the  ``org.myorg.additionalfiletemplates``  node and choose New > Other. Under Categories, choose Java. Under File Types, choose Java Package Info. Click Next. Click Finish. A Java class named  ``package-info.java``  is created. Redefine its content as follows:
-
+1. Right-click the  ``org.myorg.additionalfiletemplates``  node and choose New > Other. Under Categories, choose Java. Under File Types, choose Java Package Info. Click Next. Click Finish. A Java class named  ``package-info.java``  is created. Redefine its content as follows:
 
 [source,java]
 ----
@@ -249,7 +246,6 @@ import org.netbeans.api.templates.TemplateRegistration;
 import org.openide.util.NbBundle.Messages;
                     
 ----
-
 
 [start=3]
 1. Make sure that the structure of the module is as follows:
@@ -270,8 +266,7 @@ The IDE uses an Ant build script to build and install your module. The build scr
 1. Choose File > New Project (Ctrl-Shift-N) and create a new project.
 
 [start=3]
-1. 
-Right-click the project and choose New > Other. The New File dialog opens and displays the new file template. It should look something like this, although your icon will probably be different:
+1. Right-click the project and choose New > Other. The New File dialog opens and displays the new file template. It should look something like this, although your icon will probably be different:
 
 
 image::images/filetemplates_71_new-file.png[]


### PR DESCRIPTION
Added the `:registration:` tag with today's date and fixed the numbering issues. Apparently, AsciiDoc does not abide by the `[start=#]` option if there is a newline immediately following the number:

```
[start=3]
1.
Text here...
```
So, I removed those newlines so that the text for the numbered point is on the same line as the number. Every appears correct in the preview now.

-SC