### PR TITLE
Update javase-intro.adoc

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro.adoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro.adoc
@@ -23,7 +23,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
-:reviewed: 2019-02-24
+:reviewed: 2023-02-25
 :syntax: true
 :source-highlighter: pygments
 :icons: font
@@ -144,7 +144,7 @@ Type or paste in the following method code:
 ----
 
     public static String acrostic(String[] args) {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         for (int i = 0; i < args.length; i++) {
             if (args[i].length() > i) {
                 b.append(args[i].charAt(i));


### PR DESCRIPTION
Performed these updates:

Changed `StringBuffer` to `StringBuilder` since the `StringBuffer` has said, since JDK5:

>The `StringBuilder` class should generally be used in preference to this one, as it supports all of the same operations but it is faster, as it performs no synchronization.

-SC