### PR TITLE
asciidoctor build fixes

### DIFF
--- a/netbeans.apache.org/src/content/blogs/geertjan/index.adoc
+++ b/netbeans.apache.org/src/content/blogs/geertjan/index.adoc
@@ -27,7 +27,7 @@
 :toc-title: 
 
 
-:leveloffset: +2
+:leveloffset: +1
 
 include::serializing_nodes.adoc[]
 

--- a/netbeans.apache.org/src/content/download/nb123/index.adoc
+++ b/netbeans.apache.org/src/content/download/nb123/index.adoc
@@ -41,7 +41,7 @@ The full list of pull requests integrated in the 12.3 timeframe link:https://git
 
 == Java
 
-==== LSP/VS Code Integration
+=== LSP/VS Code Integration
 
 link:https://marketplace.visualstudio.com/items?itemName=ASF.apache-netbeans-java[Apache NetBeans Language Server] enhancements.
 
@@ -59,13 +59,13 @@ link:https://marketplace.visualstudio.com/items?itemName=ASF.apache-netbeans-jav
  - Don't show reload/save dialogs: I didn't find the appropriate PR and it's a too small detail to mention IMHO
  - Properly stop Maven execution from LSP/DAP: https://github.com/apache/netbeans/pull/2679
 
-==== nb-javac
+=== nb-javac
 
  - Update to (Maven distributed) nbjavac 15.0.0.2: https://github.com/apache/netbeans/pull/2759
  - Fix an issue where permits is treated as a keyword: https://github.com/apache/netbeans/pull/2759
  - Test case for nb-javac for JDK 15: https://github.com/apache/netbeans/pull/2562
 
-==== Gradle
+=== Gradle
  - Favorite tasks can be added to Gradle Navigator: https://github.com/apache/netbeans/pull/2595
  - Improved Gradle Sub-Project display on large projects: https://github.com/apache/netbeans/pull/2629
  - Fix IAE, when using composite Gradle Builds: https://github.com/apache/netbeans/pull/2606
@@ -74,13 +74,13 @@ link:https://marketplace.visualstudio.com/items?itemName=ASF.apache-netbeans-jav
 
 Complete PHP 8.0 syntax is supported, though code completion for attributes and named parameters is not implemented yet.
 
-==== PHP 8.0 Support
+=== PHP 8.0 Support
  - Constructor Property Promotion: https://github.com/apache/netbeans/pull/2674
  - Named Arguments: https://github.com/apache/netbeans/pull/2704
  - Attribute Syntax: https://github.com/apache/netbeans/pull/2640
  - Allow trailing comma in closure use lists: https://github.com/apache/netbeans/pull/2692
 
-==== Enhancements
+=== Enhancements
  - Show and change the PHP Version of project properties on the status bar: https://github.com/apache/netbeans/pull/2681
  - Added PSR-4 hints: https://github.com/apache/netbeans/pull/2630
  - Use complete Composer package name: https://github.com/apache/netbeans/pull/2583
@@ -93,7 +93,7 @@ Complete PHP 8.0 syntax is supported, though code completion for attributes and 
  - Improvements for constants in code completion: https://github.com/apache/netbeans/pull/2536 and https://github.com/apache/netbeans/pull/2578
  - Remove consecutive empty lines when formatting PHP code: https://github.com/apache/netbeans/pull/2573
 
-==== Fixes
+=== Fixes
  - Shared settings for PHP code generators: https://github.com/apache/netbeans/pull/2691
  - Fix code completion for traits of use and group use statements: https://github.com/apache/netbeans/pull/2533
  - Fix anonymous function formatting: https://github.com/apache/netbeans/pull/2614

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial.adoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial.adoc
@@ -97,7 +97,7 @@ The IDE must be able to find a supported tool collection on the remote host: GNU
 
 For correct operation of editor features like code completion and semantic highlighting, the Classes window, and others, your project has to be used in the correct environment, which means system includes, macro definitions, platform, etc. All of this information is gathered from the remote server and stored locally on your client system, so that when you edit locally the code assistance will work even when the project is set up to use a remote build host.
 
-[system]
+[[system]]
 == Setting Up the System
 
 Your remote Linux or Solaris server must allow communication through the SSH protocol from the client where you are running the IDE. If you want to use file sharing instead of allowing the IDE to copy files to the remote server, the file sharing must be set up in the network for both systems.

--- a/netbeans.apache.org/src/content/tutorials/nbm-maven-commandline.adoc
+++ b/netbeans.apache.org/src/content/tutorials/nbm-maven-commandline.adoc
@@ -380,19 +380,19 @@ In the next step you will create a class in the  ``java/com/mycompany/mavenplatf
     <dependency>
         <groupId>org.netbeans.api</groupId>
         <artifactId>org-netbeans-api-annotations-common</artifactId>
-        <version>RELEASE120-1</version> <!-- 2 -->
+        <version>RELEASE120-1</version> <!--2-->
     </dependency>
-    <dependency> <!-- 1 -->
+    <dependency> <!--1-->
         <groupId>org.netbeans.api</groupId>
         <artifactId>org-openide-util</artifactId>
         <version>RELEASE120-1</version>
     </dependency>
-    <dependency> <!-- 1 -->
+    <dependency> <!--1-->
         <groupId>org.netbeans.api</groupId>
         <artifactId>org-openide-awt</artifactId>
         <version>RELEASE120-1</version>
     </dependency>
-    <dependency> <!-- 1 -->
+    <dependency> <!--1-->
         <groupId>org.netbeans.api</groupId>
         <artifactId>org-openide-dialogs</artifactId>
         <version>RELEASE120-1</version>
@@ -475,7 +475,7 @@ In this section you will add the module as a dependency of the NetBeans Platform
         <artifactId>mavenPlatformApp-branding</artifactId>
         <version>${project.version}</version>
     </dependency>
-    <dependency> <!-- 1 -->
+    <dependency> <!--1-->
         <groupId>com.mycompany</groupId>
         <artifactId>mavenPlatformModuleA</artifactId>
         <version>1.0-SNAPSHOT</version>

--- a/netbeans.apache.org/src/content/tutorials/nbm-projecttype.adoc
+++ b/netbeans.apache.org/src/content/tutorials/nbm-projecttype.adoc
@@ -848,7 +848,7 @@ When you click the OK button, you will see a message in the status bar. The mess
 
 You now have the start of a project customizer.
 
-[[projectcustomizer]]
+[[projectsubtype]]
 === Creating and Registering the Project Subprojects
 
 In this section, you learn how to create new project types that are nested within other project types:
@@ -1035,7 +1035,7 @@ Using the instructions in this subsection, you can create a richly structured an
 
 In this section, you have defined the basic infrastructure of a new type of project in your NetBeans Platform application.
 
-[[projectsubtype]]
+[[registeringprojectypeasprojecsample]]
 == Registering the Project Type as Project Sample
 
 In this section, we create some project samples that make use of our project type. We also register these project samples in the New Project window of our application.

--- a/netbeans.apache.org/src/content/tutorials/nbm-quick-start.adoc
+++ b/netbeans.apache.org/src/content/tutorials/nbm-quick-start.adoc
@@ -467,7 +467,7 @@ Expand the Libraries entries to verify the dependency as been added:
 image::images/quickstart_platform_new-impl-13.png[]
 
 [start=6]
-6. Now we can modify the `WordTopComponent.java` implementation to load implementations of the "WordFilter" interface. Replace the previous implementation (which was hard-coded to just upper-case text) with the following:
+1. Now we can modify the `WordTopComponent.java` implementation to load implementations of the "WordFilter" interface. Replace the previous implementation (which was hard-coded to just upper-case text) with the following:
 
 
 [source,java]

--- a/netbeans.apache.org/src/content/wiki/APITest.adoc
+++ b/netbeans.apache.org/src/content/wiki/APITest.adoc
@@ -30,7 +30,7 @@
 :toc-title:
 :experimental:
 
-include::SigTest.asciidoc[leveloffset=1]
+include::SigTest.adoc[leveloffset=1]
 
 [NOTE]
 ====

--- a/netbeans.apache.org/src/content/wiki/DevFaqActionContextSensitive.adoc
+++ b/netbeans.apache.org/src/content/wiki/DevFaqActionContextSensitive.adoc
@@ -76,11 +76,11 @@ If you want to add this action into a context menu of a node you have to overwri
 
 If you need something more featureful, there are a few options, old and new:
 
-=== NodeAction
+== NodeAction
 
 link:https://bits.netbeans.org/dev/javadoc/org-openide-nodes/org/openide/util/actions/NodeAction.html[NodeAction] is somewhat more flexible, but requires more code to implement.  It is just passed the array of activated nodes whenever that changes, and can choose to enable or disable itself as it wishes.  Essentially this is just an action that automagically xref:DevFaqTrackingExplorerSelections.adoc[tracks the global Node selection].
 
-=== Roll your own
+== Roll your own
 
 The following is relatively simple and affords a way to perform whatever enablement logic you like (`NodeAction` can do that too, but this might be a little more straightforward and your code doesn't have to worry about nodes at all: xref:DevFaqWhatIsANode.adoc[DevFaqWhatIsANode]).  To understand how this works, see xref:DevFaqTrackGlobalSelection.adoc[DevFaqTrackGlobalSelection]:
 
@@ -138,7 +138,7 @@ public class FooAction extends AbstractAction implements LookupListener, Context
 
 ----
 
-=== Deprecated CookieAction
+== Deprecated CookieAction
 
 In many older (pre-NB 6.8) examples you may find link:https://bits.netbeans.org/dev/javadoc/org-openide-nodes/org/openide/util/actions/CookieAction.html[CookieAction]. It should be (but is not) deprecated. The original info is left here for reference and/or old code maintenance:
 
@@ -146,7 +146,7 @@ link:https://bits.netbeans.org/dev/javadoc/org-openide-nodes/org/openide/util/ac
 
 Being an older class, under the hood it is using xref:DevFaqLookupCookie.adoc[Node.getCookie()], so your action will only be sensitive to things actually returned by that method - in other words, only objects that implement the marker interface `Node.Cookie` can work here.
 
-=== Not-Yet-Official spi.actions
+== Not-Yet-Official spi.actions
 
 This module is part of the platform as of 6.8, but has not yet become official API (and nobody seems to be willing to make it stable API, so judge your own decisions based on this fact).  Nonetheless it is there, it is not changing and straightforward to use.  The example below opens a visual editor window if an instance of RAFDataObject is selected and has a RandomAccessFile in its lookup:
 

--- a/netbeans.apache.org/src/content_ja/kb/docs/ide/clearcase_ja.adoc
+++ b/netbeans.apache.org/src/content_ja/kb/docs/ide/clearcase_ja.adoc
@@ -44,9 +44,9 @@ image::images/netbeans-stamp-80-74-73.png[title="このページの内容は、N
 |===
 |ソフトウェアまたはリソース |必須バージョン 
 
-|link:https://netbeans.org/downloads/index.html[+NetBeans IDE+] |バージョン6.9以降 
+|link:https://netbeans.org/downloads/index.html[NetBeans IDE] |バージョン6.9以降 
 
-|link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[+Java Development Kit (JDK)+] |バージョン6、7または8 
+|link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java Development Kit (JDK)] |バージョン6、7または8 
 
 |ClearCaseクライアント・ソフトウェア |V 7.0以降 
 
@@ -84,7 +84,7 @@ NetBeans IDEは、コンピュータ上の ``$PATH`` システム変数を使用
 1. メイン・メニューから「ツール」>「オプション」(Macでは「NetBeans」>「プリファレンス」)を選択します。「オプション」ダイアログが開きます。
 2. ダイアログの上部にある「その他」アイコンを選択し、「バージョン管理」タブをクリックします。「バージョン管理システム」下の左側のペインで、「ClearCase」を選択します。ダイアログのメイン・ウィンドウに、ClearCaseのユーザー定義オプションが表示されます。
 
- [.feature]
+[.feature]
 --
 
 image::images/cc-options-small.jpg[role="left", link="images/cc-options.jpg"]
@@ -137,7 +137,7 @@ ClearCaseバージョン管理プロジェクトを開くには:
 
 1. 「プロジェクト」ウィンドウでプロジェクト・ノードを右クリックし、「ソース管理に追加」を選択します。「追加」ダイアログが開き、IDEで自動的に無視されない新規view-privateファイルが表示されます。
 
- [.feature]
+[.feature]
 --
 
 image::images/add-dialog-small.jpg[role="left", link="images/add-dialog.jpg"]

--- a/netbeans.apache.org/src/content_ja/kb/docs/ide/subversion_ja.adoc
+++ b/netbeans.apache.org/src/content_ja/kb/docs/ide/subversion_ja.adoc
@@ -91,7 +91,7 @@ Subversion実行可能ファイルのパスをIDEに設定するには:
 1. メイン・メニューから「ツール」→「オプション」(OS Xでは「NetBeans」→プリファレンス)を選択します。「オプション」ダイアログが開きます。
 2. ダイアログの上部にある「その他」アイコンを選択し、「バージョン管理」タブをクリックします。「バージョン管理システム」下の左側のペインで、「Subversion」を選択します。ダイアログのメイン・ウィンドウに、Subversionのユーザー定義オプションが表示されます。
 
- [.feature]
+[.feature]
 --
 
 image::images/svn-options-small.png[role="left", link="images/svn-options.png"]

--- a/netbeans.apache.org/src/content_pt_BR/kb/docs/ide/clearcase_pt_BR.adoc
+++ b/netbeans.apache.org/src/content_pt_BR/kb/docs/ide/clearcase_pt_BR.adoc
@@ -44,9 +44,9 @@ image::images/netbeans-stamp-80-74-73.png[title="O conteúdo desta página se ap
 |===
 |Software ou Recurso |Versão Necessária 
 
-|link:https://netbeans.org/downloads/index.html[+NetBeans IDE+] |versão 6.9 e mais recente 
+|link:https://netbeans.org/downloads/index.html[NetBeans IDE] |versão 6.9 e mais recente 
 
-|link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[+JDK (Java Development Kit)+] |versão 6, 7 ou 8 
+|link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK (Java Development Kit)] |versão 6, 7 ou 8 
 
 |Software cliente do ClearCase |V 7.0 ou posterior 
 
@@ -84,7 +84,7 @@ O NetBeans IDE tenta automaticamente identificar o local do arquivo executável 
 1. Escolha Ferramentas > Opções (NetBeans > Preferências no Mac) no menu principal. A caixa de diálogo Opções é aberta.
 2. Selecione o ícone Diversos na parte superior da caixa de diálogo e clique na guia Controle de Versão. No painel esquerdo, em Sistemas de Controle de Versão, selecione ClearCase. As opções definidas pelo usuário para o ClearCase são exibidas na janela principal da caixa de diálogo:
 
- [.feature]
+[.feature]
 --
 
 image::images/cc-options-small.jpg[role="left", link="images/cc-options.jpg"]
@@ -137,7 +137,7 @@ Agora que o seu projeto está criado, você pode sincronizá-lo com um servidor 
 
 1. Clique com o botão direito do mouse no nó do projeto na janela Projetos e escolha Adicionar ao controle de código-fonte. A caixa de diálogo Adicionar se abre listando todos os novos arquivos de view privada que não são ignorados automaticamente pelo IDE:
 
- [.feature]
+[.feature]
 --
 
 image::images/add-dialog-small.jpg[role="left", link="images/add-dialog.jpg"]

--- a/netbeans.apache.org/src/content_pt_BR/kb/docs/ide/subversion_pt_BR.adoc
+++ b/netbeans.apache.org/src/content_pt_BR/kb/docs/ide/subversion_pt_BR.adoc
@@ -87,7 +87,7 @@ Para definir o caminho para o arquivo executável do Subversion no IDE:
 1. Escolha Ferramentas > Opções(NetBeans > Preferências no OS X) a partir do menu principal. A caixa de diálogo Opções é aberta.
 2. Selecione o ícone Diversos na parte superior da caixa de diálogo e clique na guia Controle de Versão. No painel esquerdo, em Sistemas de Controle de Versão, selecione Subversion. As opções definidas pelo usuário para o Subversion são exibidas na janela principal da caixa de diálogo:
 
- [.feature]
+[.feature]
 --
 
 image::images/svn-options-small.png[role="left", link="images/svn-options.png"]

--- a/netbeans.apache.org/src/content_ru/kb/docs/ide/clearcase_ru.adoc
+++ b/netbeans.apache.org/src/content_ru/kb/docs/ide/clearcase_ru.adoc
@@ -84,7 +84,7 @@ IDE NetBeans автоматически выполняет попытку опр
 1. Выберите Tools ("Сервис") > Options ("Параметры") (NetBeans > Preferences ("Настройки") на Mac) из главного меню. Откроется диалоговое окно Options ("Параметры").
 2. Выберите значок Miscellaneous ("Разное") наверху диалогового окна, затем щелкните вкладку Versioning ("Управление версии"). В левой панели, под Versioning Systems ("Системы управления версиями"), выберите ClearCase. Определенные пользователем параметры ClearCase отобразятся в основном окне диалога:
 
- [.feature]
+[.feature]
 --
 
 image::images/cc-options-small.jpg[role="left", link="images/cc-options.jpg"]
@@ -137,7 +137,7 @@ image::images/cc-options-small.jpg[role="left", link="images/cc-options.jpg"]
 
 1. Щелкните правой кнопкой мыши узел проекта в окне проектов и выберите Add to Source Control ("Добавить под контроль версий"). Откроется диалоговое окно добавления, в котором перечислены все новые файлы для частного просмотра, кроме игнорируемых средой IDE автоматически:
 
- [.feature]
+[.feature]
 --
 
 image::images/add-dialog-small.jpg[role="left", link="images/add-dialog.jpg"]

--- a/netbeans.apache.org/src/content_ru/kb/docs/ide/subversion_ru.adoc
+++ b/netbeans.apache.org/src/content_ru/kb/docs/ide/subversion_ru.adoc
@@ -91,7 +91,7 @@ IDE NetBeans автоматически выполняет попытку опр
 1. Выберите 'Сервис' > 'Параметры' ('NetBeans'> 'Предпочтения' в OS X) в главном меню. Откроется диалоговое окно Options ("Параметры").
 2. Выберите значок Miscellaneous ("Разное") наверху диалогового окна, затем щелкните вкладку Versioning ("Управление версии"). В левой панели под заголовком Versioning Systems ("Системы контроля версий") выберите Subversion. Параметры пользователя Subversion отображаются в главном окне диалога:
 
- [.feature]
+[.feature]
 --
 
 image::images/svn-options-small.png[role="left", link="images/svn-options.png"]

--- a/netbeans.apache.org/src/content_zh_CN/kb/docs/ide/clearcase_zh_CN.adoc
+++ b/netbeans.apache.org/src/content_zh_CN/kb/docs/ide/clearcase_zh_CN.adoc
@@ -84,7 +84,7 @@ NetBeans IDE 尝试使用计算机中的  ``$PATH``  系统变量自动标识  `
 1. 从主菜单中选择 "Tools"（工具）> "Options"（选项）；在 Mac 上为 "NetBeans" > "Preferences"（首选项）。"Options"（选项）对话框打开。
 2. 选择对话框顶部的 "Miscellaneous"（其他）图标，然后单击 "Versioning"（版本控制）标签。在 "Versioning Systems"（版本控制系统）下面的左侧窗格中，选择 ClearCase。对话框主窗口中将会显示 ClearCase 的用户定义选项：
 
- [.feature]
+[.feature]
 --
 
 image::images/cc-options-small.jpg[role="left", link="images/cc-options.jpg"]
@@ -137,7 +137,7 @@ image::images/cc-options-small.jpg[role="left", link="images/cc-options.jpg"]
 
 1. 在 "Projects"（项目）窗口中右键单击项目节点，选择 "Add to source control"（添加到源代码控制中）。此时将打开 "Add"（添加）对话框，其中列出 IDE 自动忽略的所有新建的视图私有文件：
 
- [.feature]
+[.feature]
 --
 
 image::images/add-dialog-small.jpg[role="left", link="images/add-dialog.jpg"]

--- a/netbeans.apache.org/src/content_zh_CN/kb/docs/ide/subversion_zh_CN.adoc
+++ b/netbeans.apache.org/src/content_zh_CN/kb/docs/ide/subversion_zh_CN.adoc
@@ -88,7 +88,7 @@ NetBeans IDE 会尝试使用计算机中的 `$PATH` 系统变量自动标识 Sub
 1. 从主菜单中选择 "Tools"（工具）> "Options"（选项）；在 OS X 上为 "NetBeans" > "Preferences"（首选项）。"Options"（选项）对话框打开。
 2. 选择对话框顶部的 "Miscellaneous"（其他）图标，然后单击 "Versioning"（版本控制）标签。在 "Versioning Systems"（版本控制系统）下的左窗格中，选择 "Subversion"。对话框主窗口中将会显示 Subversion 的用户定义选项：
 
- [.feature]
+[.feature]
 --
 
 image::images/svn-options-small.png[role="left", link="images/svn-options.png"]


### PR DESCRIPTION
some block where misplaced and prefer clean build to get new issue triggering log
some id were not ok by construction.
It's pure technical, not semantic chek.

to get better file identification using asciidoctor **/*.adoc in src folder. (otherwise it say stdin )
