### PR TITLE
Add detail to section on creating JUnit Tests

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro.adoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro.adoc
@@ -49,7 +49,7 @@ This tutorial takes approximately 30 minutes to complete. If you would like to d
 
 == Project Setup
 
-The application you create will contain two projects:
+The application you create will contain two projects that will use Ant to handle the build process:
 
 * A Java Class Library project, *MyLib*, in which you will create a utility class.
 * A Java Application project, *MyApp*, with a main class that implements a method from the library project's utility class.
@@ -274,7 +274,7 @@ In the *Create/Update Tests* dialog box, click *OK* to run the command with the 
 
 In the *Projects* window you will see that the IDE has created the `org.me.mylib` package, the `LibClassTest.java` file in the *MyLib > Test Packages*  folder and, created the *MyLib > Test Libraries* folder. Finally the file `LibClassTest.java` is opened in the editor.
 
-In the *Projects* window, right-click the *Test Libraries* node and select *Properties*.  In the *Project Properties - MyLib* window, select *Categories: Libraries*. In the right-hand pane select the *Compile Tests* tab and click the ` *+* ` button. From the pop-up list select *Add Library*, from the *Global Libraries* folder select `JUnit 4.x` and click *Add Library* repeat, this time selecting the `Hamcrest 1.x` library.
+In the *Projects* window, right-click the *Test Libraries* node and select *Properties*.  In the *Project Properties - MyLib* window, select *Categories: Libraries*. In the right-hand pane select the *Compile Tests* tab and click the ` *+* ` button to the right of the *Classpath* heading. From the pop-up list select *Add Library*, from the *Global Libraries* folder select `JUnit 4.x` and click *Add Library* repeat, this time selecting the `Hamcrest 1.x` library.  Select the *Run Tests* tab and add these libraries to its classpath.
 
 In `LibClassTest.java`, delete the body of the `public void testAcrostic()` method and, in place of the deleted lines, type or paste in the following:
 


### PR DESCRIPTION
The current paragraph does not mention the following details of the Project Properties dialog:
1.  Libraries may be added to the module path or the class path. It seems the JUnit and Hamfest libraries should be added to the classpath.
2.  These libraries must also be added to the Run Test tab for the tests to be run successfully.