### PR TITLE
Removed references to the SpotBugs plugin and JSR305

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect.adoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect.adoc
@@ -32,7 +32,7 @@
 
 The NetBeans IDE Java Editor has a static code analysis feature, which is a tool for finding potential problems and detecting inconsistencies in your source code.
 
-In this tutorial, you will learn how to perform static analysis of your Java code using FindBugs and NetBeans Java Hints without actually running your applications.
+In this tutorial, you will learn how to perform static analysis of your Java code using NetBeans Java Hints without actually running your applications.
 
 == Requirements
 
@@ -43,17 +43,6 @@ In this tutorial, you will learn how to perform static analysis of your Java cod
 
 |link:https://web.archive.org/web/20131021173103/https://netbeans.org/project_downloads/samples/Samples/Java/library.zip[library.zip] |NetBeans project 
 
-|link:http://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/2.0.0/jsr305-2.0.0.jar[jsr305-2.0.0.jar] |Java Specification Request intended to improve the effectiveness of static analysis tools 
-|===
-
-NOTE: ``jsr305-2.0.0.jar``  is included into  ``library.zip``  for the purposes of this tutorial.
-
-If using another NetBeans project, link:http://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/2.0.0/jsr305-2.0.0.jar[+jsr305-2.0.0.jar+] should be downloaded and added to the Libraries folder of the your project in the IDE as follows:
-[lowerroman, start=1]
-. Right-click the Libraries folder and choose the Add JAR/Folder from the popup menu.
-. In the Add JAR/Folder dialog box, specify the path to the downloaded  ``jsr305-2.0.0.jar``  file and click Open.
-
-image::images/jar.png[]
 
 == Setting Up the Tutorial Environment
 
@@ -61,38 +50,12 @@ In addition to the required software listed above you should have the following 
 
 * The link:https://web.archive.org/web/20131021173103/https://netbeans.org/project_downloads/samples/Samples/Java/library.zip[library.zip] file should be unzipped into your NetBeans project folder and opened in the NetBeans IDE.
 
-The FindBugs plugin should be downloaded and installed into the NetBeans IDE as follows:
-
-[arabic, start=1]
-. Choose Source > Inspect from the main IDE's menu.
-. In the Inspect dialog box, click Install.
-
-[.feature]
---
-
-image::images/inspect-small.png[role="left", link="images/inspect.png"]
-
---
-[start=3]
-. In the Installer dialog box, click Next to proceed with the installation.
-
-[.feature]
---
-
-image::images/plugin-small.png[role="left", link="images/plugin.png"]
-
---
-[start=4]
-. Review the license agreement, select the license agreement option, and click Install.
-. When the installation is complete, click Finish.
-
 == Using Predefined Configurations
 
 You can use the following predefined configurations when inspecting your code in the NetBeans IDE:
 
 * <<all,All Analyzers>>
 * <<hints,NetBeans Java Hints>>
-* <<fb,FindBugs>>
 * <<default,Default>>
 
 [[all]]
@@ -112,8 +75,6 @@ The  ``All Analyzers``  configuration deploys all static code analysis tools ava
 image::images/allconfig-small.png[role="left", link="images/allconfig.png"]
 
 --
-
-NOTE: You need to install the <<plugin,FindBugs>> plugin to run this configuration for the first time.
 
 [start=4]
 . Click Inspect.
@@ -193,85 +154,6 @@ a|image:images/categorizebutton.png[] |
 *Categorize* |Toggles the collapsed view of the problems detected in a file, project, or package or the categorized view of all the detected problems. 
 |===
 
-[[fb]]
-=== Finding Potential Problems in Java Code with FindBugs
-
-The  ``FindBugs``  configuration available in the IDE enables you to find a wide range of potential problems in your code. It invokes the popular open source FindBugs tool for code analysis in Java. The bug report gets generated and is displayed in the Inspector Window of the NetBeans IDE, which categorizes all the found problems and allows direct navigation from the bugs in the report to the suspicious code. You can also read a bug description in the adjacent window or review it at the link:http://findbugs.sourceforge.net/bugDescriptions.html[+FindBugs Bug Descriptions+] page by the pointer provided at the top of the left frame.
-
-NOTE: You need to install the <<plugin,FindBugs>> plugin to run this configuration for the first time.
-
-*To identify potential errors in your Java code with the  ``FindBugs``  configuration, complete the following steps:*
-
-. Open the  ``library``  project in the NetBeans IDE and choose Source > Inspect from the main toolbar.
-. In the Scope drop-down list of the Inspect dialog box, select  ``Current Project (library)`` .
-
-NOTE: You can inspect a file, package, or project(s) with the  ``FindBugs``  configuration.
-
-[start=3]
-. In the Inspect dialog box, select the  ``FindBugs``  configuration.
-
-[.feature]
---
-
-image::images/fb-small.png[role="left", link="images/fb.png"]
-
---
-
-
-
-[start=4]
-. Click the Inspect button to initiate the static code analysis.
-The result of the static code analysis is displayed in the Inspector Window below the Source Editor.
-The description of the selected bug is displayed in the frame on the right.
-
-[.feature]
---
-
-image::images/inspector-small.png[role="left", link="images/inspector.png"]
-
---
-
-[start=5]
-. Alternatively, click the <<categorize,Categorize>> button in the toolbar on the left to view the bugs grouped into categories.
-
-image::images/fbcat.png[]
-
-NOTE: If you double-click an issue in the expanded list, the IDE displays the reported issue in the Source Editor. + 
-Press kbd:[Alt+Enter] to view the bug description in the source code.
-
-[.feature]
---
-
-image::images/source-editor-small.png[role="left", link="images/source-editor.png"]
-
---
-
-NOTE: Potential errors are highlighted in the code with exclamation mark icons (image:images/exclamation.png[]) in the left margin of the Source Editor.
-
-*To enable FindBugs in the Java Editor, complete the following steps:*
-
-. Choose Tools > Options in the main IDE's toolbar.
-. Select the Editor tab and choose Hints.
-. Choose  ``FindBugs``  in the Language drop-down list.
-
-[.feature]
---
-
-image::images/fb-editor-small.png[role="left", link="images/fb-editor.png"]
-
---
-
-[start=4]
-. Select the Run FindBugs in Editor option.
-. Click OK.
-If you now press kbd:[Alt+Enter] in the source code where a bug is reported and click the black arrow pointing to the right at the end of the displayed tip, the IDE shows some fixing options for a potential bug.
-
-[.feature]
---
-
-image::images/fbenabled-small.png[role="left", link="images/fbenabled.png"]
-
---
 
 [[default]]
 === Customizing a Default Configuration
@@ -289,7 +171,7 @@ image::images/configurations-db.png[]
 
 [start=4]
 . Ensure  ``Default``  is selected in the Configurations drop-down list.
-. In the Analyzer drop-down list, select the  ``JRE 8 Profiles Conformance`` ,  ``Netbeans Java Hints`` , or  ``FindBugs``  analyzer.
+. In the Analyzer drop-down list, select the  ``JRE 8 Profiles Conformance``  or  ``Netbeans Java Hints`` analyzer.
 . Depending on the choice of the analyzer in the previous step, select the profile to validate, the inspections, or bugs you need to include into your  ``Default``  configuration.
 
 [.feature]
@@ -320,7 +202,7 @@ A  ``newConfig``  configuration is created and added to the Configurations drop-
 image::images/newconfig-created.png[]
 
 [start=5]
-. In the Analyzer drop-down list, choose  ``JRE 8 Profiles Conformance`` ,  ``Netbeans Java Hints`` , or  ``FindBugs`` .
+. In the Analyzer drop-down list, choose  ``JRE 8 Profiles Conformance`` or  ``Netbeans Java Hints``.
 . Specify the profile, inspections, or bugs to be included into your own configuration.
 . Click OK to save your edits and close the Configurations dialog box.
 The created  ``newConfig``  configuration is available in the Configuration drop-down list of the Inspect dialog box.


### PR DESCRIPTION
Removed references to the SpotBugs plugin and JSR305 from the Static Code Analysis tutorial.