### PR TITLE
Antora preview in staging mode

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,3 +7,5 @@ github:
     - jbake
 publish:
   whoami: asf-site
+staging:
+  profile: antora # See https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-Stagingawebsitepreviewdomain


### PR DESCRIPTION
This should enable the preview of the HTML/CSS/etc. content in the "antora" branch into 

https://netbeans-antora.staged.apache.org/ 

Let's see if this works.
