### PR TITLE
Rollback antora preview.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,5 +7,3 @@ github:
     - jbake
 publish:
   whoami: asf-site
-staging:
-  profile: antora # See https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-Stagingawebsitepreviewdomain


### PR DESCRIPTION
The .asf.yaml must be in the antora branch, ASF-infra explains. Let's do that